### PR TITLE
feat: execution workflow MISO

### DIFF
--- a/tests/pilot_benchmark/snakemake/README.md
+++ b/tests/pilot_benchmark/snakemake/README.md
@@ -18,13 +18,21 @@ Adjust file paths for dataset run in `configs/config.miso.yaml`.
 * Miso also requires an own configuration file and is specified in `configs/miso_settings.txt`.
 * The samples table `configs/samples.csv` must include the following columns: **sample** and **bam**, for the sample name and absolute path to BAM file respectively. 
 
-Run the MISO pipeline with
+Run the MISO pipeline with conda environment:
 
 ``` bash
 bash run_miso.sh
 ```
 
-The benchmark output file is `benchmark.Q1_miso.json` and follows the benchmark specification. 
+Run the MISO pipeline with singularity containers:
+
+``` bash
+bash run_miso_singularity.sh
+```
+
+> Note: Running this requires that singularity is installed.
+
+The benchmark output file is `AA_MISO_04.json` and follows the benchmark specification. 
 It contains the sum of run times for all samples and the index generation and the maximum Proportional Set Size (PSS) from all rules.
 
 ## Current challenges

--- a/tests/pilot_benchmark/snakemake/run_miso_singularity.sh
+++ b/tests/pilot_benchmark/snakemake/run_miso_singularity.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+snakemake \
+    --rerun-incomplete \
+    --snakefile="workflows/miso.smk" \
+    --configfile="configs/config.miso.yaml" \
+    --cores 4 \
+    --use-singularity \
+    --singularity-args="--bind ${PWD}/../../test_data"\
+    --printshellcmds 

--- a/tests/pilot_benchmark/snakemake/workflows/miso.smk
+++ b/tests/pilot_benchmark/snakemake/workflows/miso.smk
@@ -12,7 +12,7 @@ rule finish:
         In this case a json file with compute resources used (OUTCODE 04)
     """
     input:
-        os.path.join(config["out_dir"],config["benchmarks"], config["param_code"], "_".join(config["param_code"], config["method"], "04.json")
+        os.path.join(config["out_dir"],config["benchmarks"], config["param_code"], "_".join([config["param_code"], config["method"], "04.json"]))
 
 ###########
 # Preprocessing: obtain suitable input formats
@@ -29,6 +29,8 @@ rule index:
         dir=os.path.join(config["out_dir"], "indexed")
     conda: 
         os.path.join(config["envs"], "miso.yaml")
+    singularity: 
+        "docker://quay.io/biocontainers/misopy:0.5.4--py27heb79e2c_4"
     benchmark:
         os.path.join(config["out_dir"], config["benchmarks"], "index.tsv")
     log:
@@ -54,6 +56,8 @@ rule execute:
     threads: 4
     conda: 
         os.path.join(config["envs"], "miso.yaml")
+    singularity: 
+        "docker://quay.io/biocontainers/misopy:0.5.4--py27heb79e2c_4"
     benchmark:
         os.path.join(config["out_dir"], config["benchmarks"], "execute.{sample}.tsv")
     log:
@@ -83,7 +87,7 @@ rule gather_benchmark_Q1:
         T2=expand(os.path.join(config["out_dir"], config["benchmarks"], "execute.{sample}.tsv"),
             sample = samples.index)
     output:
-        os.path.join(config["out_dir"],config["benchmarks"], config["param_code"], "_".join(config["param_code"], config["method"], "04.json")
+        os.path.join(config["out_dir"],config["benchmarks"], config["param_code"], "_".join([config["param_code"], config["method"], "04.json"]))
     run:
         import pandas as pd
         import json
@@ -92,7 +96,7 @@ rule gather_benchmark_Q1:
             df = pd.read_table(file, sep="\t", header = 0)
             res['run_time_sec'] += df.s.values.mean()
             max_mem = df.max_pss.max()
-            if type(max_mem) is not int:
+            if type(max_mem) is str:
                 continue
             if max_mem > res['max_mem_mib']:
                 res['max_mem_mib'] = max_mem 


### PR DESCRIPTION
Fixes #63.

Added singularity keyword to MISO rules. 

Pilot now runs either with conda environments with `run_miso.sh` or with singularity containers with `run_miso_singularity.sh`.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] My code follows the templates/style guidelines of the repository
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
