### PR TITLE
fix: account for strand in QAPA post-processing

### DIFF
--- a/execution_workflows/QAPA/bin/make_quant_bed.py
+++ b/execution_workflows/QAPA/bin/make_quant_bed.py
@@ -9,6 +9,13 @@ header_fields=['chrom','chromStart','chromEnd','name','score','strand']
 qapa_quant_bed.write('\t'.join(header_fields)+'\n')
 for ln in qapa_results_file:
  ln=ln.strip().split('\t')
- fields=[ln[4],ln[8],ln[9],ln[0],ln[13],ln[7]]
+ strand = ln[7] 
+ #if "+" strand gene we want to grab "UTR3.End" as PAS
+ if strand == '+': 
+  pas_coord = int(ln[9])
+ #if "-" strand gene we need "UTR3.Start" as PAS
+ else: 
+  pas_coord = int(ln[8])
+ fields=[ln[4], str(pas_coord-1), str(pas_coord),ln[0],ln[13],ln[7]]
  qapa_quant_bed.write('\t'.join(fields)+'\n')
 qapa_quant_bed.close()

--- a/execution_workflows/QAPA/bin/make_quant_bed.py
+++ b/execution_workflows/QAPA/bin/make_quant_bed.py
@@ -6,16 +6,16 @@ qapa_results_file=open(sys.argv[1],'r')
 qapa_results_file.readline()
 qapa_quant_bed=open(sys.argv[2],'w')
 header_fields=['chrom','chromStart','chromEnd','name','score','strand']
-qapa_quant_bed.write('\t'.join(header_fields)+'\n')
 for ln in qapa_results_file:
  ln=ln.strip().split('\t')
- strand = ln[7] 
+ strand = ln[7]
+ chrm = ln[4][3:] #specification requires no leading "chr"
  #if "+" strand gene we want to grab "UTR3.End" as PAS
  if strand == '+': 
   pas_coord = int(ln[9])
  #if "-" strand gene we need "UTR3.Start" as PAS
  else: 
   pas_coord = int(ln[8])
- fields=[ln[4], str(pas_coord-1), str(pas_coord),ln[0],ln[13],ln[7]]
+ fields=[chrm, str(pas_coord-1), str(pas_coord),ln[0],ln[13],ln[7]]
  qapa_quant_bed.write('\t'.join(fields)+'\n')
 qapa_quant_bed.close()


### PR DESCRIPTION
`ln[8]` and `ln[9]` correspond to "UTR3.Start" and "UTR3.End", respectively. These are genomic coordinates and so depending on the strand the actual PAS coordinate will change to being either the end of the transcript (`if strand=="+"` we need the "UTR3.End" / `ln[8]`. Otherwise we assume `strand =="-"` then we need "UTR3.Start" / `ln[8]`)

Fixes #{ISSUE_NUMBER}

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the templates/style guidelines of the repository
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code
