### PR TITLE
Update Snakemake template & docs with 'run_<challenge>' flags

### DIFF
--- a/docs/templates/snakemake/README.md
+++ b/docs/templates/snakemake/README.md
@@ -8,16 +8,20 @@ Read this section, but do NOT include it your final README.
 > * Place any scripts or subworkflows you're going to use into the directories `workflow/scripts` and `workflow/rules`, respectively.
 > * Write your workflow in `Snakefile`.
 > * Here are the [snakemake docs](https://snakemake.readthedocs.io/en/stable/index.html)
-> * The pipeline's config.yaml file should contain 'True/False' flags to run each benchmarking event ('run_identification', 'run_quantification', 'run_differential') with which the tool is compatible. Wherever possible, these flags should be compatible with one another (i.e. 'switching on' any combination of flags will produce a valid workflow). If workflows are incompatible with one another (e.g. 'run_differential' & 'run_quantification' require different workflows), this should be clearly stated in the README.
+> * The pipeline's config.yaml file should contain 'True/False' flags to run each benchmarking event ('run_identification', 'run_quantification', 'run_differential') with which the tool is compatible.
+>     * Wherever possible, these flags should be compatible with one another (i.e. 'switching on' any combination of flags will produce a valid workflow).
+>     * If workflows are incompatible with one another (e.g. 'run_differential' & 'run_quantification' require different workflows), this should be clearly stated in the README.
+>     * If a tool does not output files compatible with a challenge, this should be clearly stated in the README. The  corresponding config.yaml flag should be set to False and enforced in the Snakefile (there is commented code in the template Snakefile to do this).
 > * General good practices:
 >     * Test your code with [snakemake --lint](https://snakemake.readthedocs.io/en/stable/snakefiles/writing_snakefiles.html#best-practices).
 >     * One (shell) command per rule.
 >     * If samples differ in a meaningful way (e.g. single end and paired end samples), it might be better to write subworkflows within `workflow/rules`.
 >     * Each rule has it's own [Docker container](https://www.docker.com/resources/what-container). All containers should be pushed to the [APAeval team Dockerhub](https://hub.docker.com/u/apaeval)
-> * There are some shell scripts which can be used to start a snakemake run. Adjust the name of the `config file` in these scripts:
+> * There are some shell scripts which can be used to start a snakemake run. Adjust the name of the `config file` in following scripts:
 >     * `dryrun.sh`
 >     * `rulegraph.sh` (Also adjust name of output `.png`)
 >     * `run_local.sh`
+>     * Both `dryrun.sh` and `rulegraph.sh` will execute successfully with the current template.
 > * Check out the pilot benchmark at `tests/pilot_benchmark/snakemake` for a running example. It illustrates how the execution workflow can look in practice.
 > * Adjust this `README.md`: Delete this description section and populate the sections below with your awesome experience ;)
 
@@ -35,7 +39,9 @@ Read this section, but do NOT include it your final README.
 
 ## Input & pre-processing
 
-{Describe input files and how they will be processed in order for the method to work. Describe how sample tables have to look like, and any other input that is needed (e.g. genome).}
+{Describe input files and how they will be processed in order for the method to work. Describe how sample tables have to look like, and any other input that is needed (e.g. genome).
+
+Note: A single sample table format should be sufficient for all workflows (different columns will be used based on the run mode). If not possible, clearly state that a different sample table format is required for different workflows and provide an example of each possible format.}
 
 ## Params
 

--- a/docs/templates/snakemake/README.md
+++ b/docs/templates/snakemake/README.md
@@ -8,20 +8,24 @@ Read this section, but do NOT include it your final README.
 > * Place any scripts or subworkflows you're going to use into the directories `workflow/scripts` and `workflow/rules`, respectively.
 > * Write your workflow in `Snakefile`.
 > * Here are the [snakemake docs](https://snakemake.readthedocs.io/en/stable/index.html)
-> * Create the [conda](https://docs.conda.io/en/latest/) environment named `snakemake` with `conda env create -f snakemake.yaml`. Alternatively, create an own virtual environment, but ensure to use same versions as in `snakemake.yaml`.
+> * The pipeline's config.yaml file should contain 'True/False' flags to run each benchmarking event ('run_identification', 'run_quantification', 'run_differential') with which the tool is compatible. Wherever possible, these flags should be compatible with one another (i.e. 'switching on' any combination of flags will produce a valid workflow). If workflows are incompatible with one another (e.g. 'run_differential' & 'run_quantification' require different workflows), this should be clearly stated in the README.
 > * General good practices:
 >     * Test your code with [snakemake --lint](https://snakemake.readthedocs.io/en/stable/snakefiles/writing_snakefiles.html#best-practices).
->     * One (shell) command per rule. 
->     * If samples differ in a meaningful way (e.g. single end and paired end samples), it might be better to write subworkflows within `workflow/rules`. 
->     * If applicable, each rule has it's own [Docker container](https://www.docker.com/resources/what-container) or conda environment.
+>     * One (shell) command per rule.
+>     * If samples differ in a meaningful way (e.g. single end and paired end samples), it might be better to write subworkflows within `workflow/rules`.
+>     * Each rule has it's own [Docker container](https://www.docker.com/resources/what-container). All containers should be pushed to the [APAeval team Dockerhub](https://hub.docker.com/u/apaeval)
 > * There are some shell scripts which can be used to start a snakemake run. Adjust the name of the `config file` in these scripts:
 >     * `dryrun.sh`
 >     * `rulegraph.sh` (Also adjust name of output `.png`)
 >     * `run_local.sh`
-> * Check out the pilot benchmark at `tests/pilot_benchmark/snakemake` for a running example. It illustrates how the execution workflow can look in practice. 
+> * Check out the pilot benchmark at `tests/pilot_benchmark/snakemake` for a running example. It illustrates how the execution workflow can look in practice.
 > * Adjust this `README.md`: Delete this description section and populate the sections below with your awesome experience ;)
 
 # [METHOD] {Method name as specified in Algorithm table.}
+
+## Benchmarking challenges
+
+{Bullet point list of the benchmarking challenges with which this workflow is compatible and produces challenge output files}
 
 ## Rulegraph
 
@@ -37,12 +41,14 @@ Read this section, but do NOT include it your final README.
 
 {Describe parameters needed by your METHOD.}
 
+{Describe the parameters for running different modes `--run_identification/`, `--run_quantification/`, `--run_differential`}
+
 ## Output & post-processing
 
 {Describe output files and postprocessing steps if necessary.}
 
 ## Notes
 
-{Notes about the METHOD. 
-e.g. Did you have to adjust the method's soure code?
+{Notes about the METHOD.
+e.g. Did you have to adjust the method's source code/recommended running instructions?
 }

--- a/docs/templates/snakemake/README.md
+++ b/docs/templates/snakemake/README.md
@@ -41,7 +41,7 @@ Read this section, but do NOT include it your final README.
 
 {Describe parameters needed by your METHOD.}
 
-{Describe the parameters for running different modes `--run_identification/`, `--run_quantification/`, `--run_differential`}
+{Describe the parameters for running different modes `run_identification`, `run_quantification`, `run_differential`}
 
 ## Output & post-processing
 

--- a/docs/templates/snakemake/config/[SAMPLES].csv
+++ b/docs/templates/snakemake/config/[SAMPLES].csv
@@ -1,0 +1,2 @@
+sample,bam
+siControl_R1,../../../tests/test_data/siControl_R1_2genes.bam

--- a/docs/templates/snakemake/config/config.[METHOD].yaml
+++ b/docs/templates/snakemake/config/config.[METHOD].yaml
@@ -13,19 +13,20 @@ method: "METHOD" # same as the name of the directory
 # Parameters
 
 # Flags to run/output files for each benchmarking challenge
-# REMOVE the flag from the file if the tool does not output files compatible with a challenge
 # All flags are 'True/False' to 'switch on/off' rules to produce challenge output. Valid parameter values are:
 # 'True': Run/output challenge files
 # 'False': Don't run/output challenge files
+# Note: Always set to False if the the tool does not output files compatible with a challenge
 # Note: Do not enclose True/False in quotation marks
 # If combinations of flags are incompatible with one another (e.g. run_differential requires a different workflow to run_quantification), this should be noted here and in the README
-
 
 # Whether to run steps to produce output files for identification challenge
 run_identification: True
 
+# Whether to run steps to produce output files for quantification challenge
 run_quantification: True
 
+# Whether to run steps to produce output files for differential challenge
 run_differential: True
 
 identification_output_suffix: ".identification.bed"

--- a/docs/templates/snakemake/config/config.[METHOD].yaml
+++ b/docs/templates/snakemake/config/config.[METHOD].yaml
@@ -28,6 +28,10 @@ run_quantification: True
 
 run_differential: True
 
+identification_output_suffix: ".identification.bed"
+quantification_output_suffix: ".quantification.bed"
+differential_output_file: "differential_challenge.tsv"
+
 # define method specific parameters here
 
 # Settings

--- a/docs/templates/snakemake/config/config.[METHOD].yaml
+++ b/docs/templates/snakemake/config/config.[METHOD].yaml
@@ -11,6 +11,23 @@ method: "METHOD" # same as the name of the directory
 
 
 # Parameters
+
+# Flags to run/output files for each benchmarking challenge
+# REMOVE the flag from the file if the tool does not output files compatible with a challenge
+# All flags are 'True/False' to 'switch on/off' rules to produce challenge output. Valid parameter values are:
+# 'True': Run/output challenge files
+# 'False': Don't run/output challenge files
+# Note: Do not enclose True/False in quotation marks
+# If combinations of flags are incompatible with one another (e.g. run_differential requires a different workflow to run_quantification), this should be noted here and in the README
+
+
+# Whether to run steps to produce output files for identification challenge
+run_identification: True
+
+run_quantification: True
+
+run_differential: True
+
 # define method specific parameters here
 
 # Settings

--- a/docs/templates/snakemake/workflow/Snakefile
+++ b/docs/templates/snakemake/workflow/Snakefile
@@ -3,6 +3,7 @@ For help see: https://snakemake.readthedocs.io/en/stable/index.html.
 """
 
 import pandas as pd
+import sys
 
 samples = pd.read_csv(os.path.abspath(
     config["samples"])).set_index("sample", drop=False)
@@ -10,6 +11,35 @@ samples = pd.read_csv(os.path.abspath(
 assert isinstance(config["run_identification"], bool), f"'run_identification' must be True/False boolean, {config['run_identification']} (type {type(config['run_identification'])}) was provided"
 assert isinstance(config["run_quantification"], bool), f"'run_quantification' must be True/False boolean, {config['run_quantification']} (type {type(config['run_quantification'])}) was provided"
 assert isinstance(config["run_differential"], bool), f"'run_differential' must be True/False boolean, {config['run_differential']} (type {type(config['run_differential'])}) was provided"
+
+
+def flag_info_message(flag_name, challenge_name):
+
+    if config[flag_name]:
+        sys.stderr.write(f"config['{flag_name}'] set to True - {challenge_name} challenge output to be generated\n")
+
+    elif not config[flag_name]:
+        sys.stderr.write(f"config['{flag_name}'] set to False - {challenge_name} challenge output will not be generated. Is this desired run mode?\n")
+
+
+# # Info messages
+flag_info_message("run_identification", "identification")
+flag_info_message("run_quantification", "quantification")
+flag_info_message("run_differential", "differential")
+
+# Example code to enforce flags to False
+# Use ONLY if a tool is incompatible with a given challenge
+# Delete these lines if not applicable to your workflow
+
+# if config["run_identification"] is not False:
+#     raise ValueError("'run_identification' must be set to False as tool is incompatible with the identification challenge/does not perform this task (see README for details).")
+#
+# if config["run_quantification"] is not False:
+#     raise ValueError("'run_quantification' must be set to False as tool is incompatible with the quantification challenge/does not perform this task (see README for details).")
+#
+# if config["run_differential"] is not False:
+#     raise ValueError("'run_differential' must be set to False as tool is incompatible with the differential challenge/does not perform this task (see README for details).")
+
 
 #-------------------------------------------------------------------------------
 localrules: finish

--- a/docs/templates/snakemake/workflow/Snakefile
+++ b/docs/templates/snakemake/workflow/Snakefile
@@ -107,23 +107,6 @@ rule execute_container:
 #-------------------------------------------------------------------------------
 # Postprocessing: obtain suitable output formats (for benchmarks)
 
-# rule postprocess_step_1:
-#     """A rule that does some postprocessing.
-#
-#     Note: expand() with wildcard sample gathers all samples.
-#
-#     """
-#     input:
-#         expand(os.path.join(config["out_dir"], "{sample}", "execute.out"),
-#                sample = samples.index)
-#     output:
-#         os.path.join(config["out_dir"], config["param_code"], config["method"],
-#         "_".join(config["param_code"], config["method"], "OUTCODE.ext"))
-#     log:
-#         os.path.join(config["local_log"], "postprocess_step_1.{sample}.log")
-#     shell:
-#         "(cat {input} {output}) &> {log}"
-
 
 rule postprocess_identification:
     """
@@ -201,7 +184,7 @@ rule postprocess_differential:
     """
     input:
         expand(os.path.join(config["out_dir"], "{sample}", "execute.out"),
-               sample = samples.index)
+               sample=samples.index)
     output:
         out = os.path.join(config["out_dir"],
                            config["param_code"],

--- a/docs/templates/snakemake/workflow/Snakefile
+++ b/docs/templates/snakemake/workflow/Snakefile
@@ -7,6 +7,9 @@ import pandas as pd
 samples = pd.read_csv(os.path.abspath(
     config["samples"])).set_index("sample", drop=False)
 
+assert isinstance(config["run_identification"], bool), f"'run_identification' must be True/False boolean, {config['run_identification']} (type {type(config['run_identification'])}) was provided"
+assert isinstance(config["run_quantification"], bool), f"'run_quantification' must be True/False boolean, {config['run_quantification']} (type {type(config['run_quantification'])}) was provided"
+assert isinstance(config["run_differential"], bool), f"'run_differential' must be True/False boolean, {config['run_differential']} (type {type(config['run_differential'])}) was provided"
 
 #-------------------------------------------------------------------------------
 localrules: finish
@@ -15,8 +18,39 @@ rule finish:
     """Rule that specifies the final output. Add all output files needed for the different challenges here. OUTCODE: 01 for identification challenge, 02 for quantification challenge, 03 for differential expression challenge. For more info refer to https://github.com/iRNA-COSI/APAeval/blob/main/execution_workflows/README.md
     """
     input:
-        os.path.join(config["out_dir"], config["param_code"], config["method"],
-        "_".join(config["param_code"], config["method"], "OUTCODE.ext"))
+        expand(os.path.join(config["out_dir"],
+                     config["param_code"],
+                     config["method"],
+                     "_".join([config["param_code"],
+                               config["method"],
+                               "{sample}" + config["identification_output_suffix"]
+                               ]
+                              )
+                            ),
+               sample=list(samples.index) if config["run_identification"] else []
+               ),
+        expand(os.path.join(config["out_dir"],
+                     config["param_code"],
+                     config["method"],
+                     "_".join([config["param_code"],
+                               config["method"],
+                               "{sample}" + config["quantification_output_suffix"]
+                               ]
+                              )
+                            ),
+               sample=list(samples.index) if config["run_quantification"] else []
+               ),
+        os.path.join(config["out_dir"],
+                     config["param_code"],
+                     config["method"],
+                     "_".join([config["param_code"],
+                               config["method"],
+                               config["differential_output_file"]
+                               ]
+                              )
+                     ) if config["run_differential"] else []
+
+
 
 
 #-------------------------------------------------------------------------------
@@ -27,13 +61,18 @@ rule preprocess_step_1:
     This example copies input to output and writes stdout and stderr to log.
     """
     input:
-        INPUT_FILE
+        bam = lambda wildcards:
+                pd.Series(
+                    samples.loc[wildcards.sample, "bam"]
+                ).values
     output:
-        OUTPUT_FILE
+        os.path.join(config["out_dir"],
+                     "bam_files",
+                     "{sample}.bam")
     log:
-        os.path.join(config["local_log"], "preprocess_step_1.log")
+        os.path.join(config["local_log"], "preprocess_step_1.{sample}.log")
     shell:
-        "(cp {input} {output}) &> {log}"
+        "(cp {input.bam} {output}) &> {log}"
 
 
 #-------------------------------------------------------------------------------
@@ -43,10 +82,9 @@ rule execute_container:
     """Execution rule in a container (e.g. Dockerfile).
     """
     input:
-        bam=lambda wildcards:
-                pd.Series(
-                    samples.loc[wildcards.sample, "bam"]
-                ).values
+        bam = os.path.join(config["out_dir"],
+                           "bam_files",
+                           "{sample}.bam")
     output:
         out=os.path.join(config["out_dir"], "{sample}", "execute.out")
     params:
@@ -69,23 +107,128 @@ rule execute_container:
 #-------------------------------------------------------------------------------
 # Postprocessing: obtain suitable output formats (for benchmarks)
 
-rule postprocess_step_1:
-    """A rule that does some postprocessing.
+# rule postprocess_step_1:
+#     """A rule that does some postprocessing.
+#
+#     Note: expand() with wildcard sample gathers all samples.
+#
+#     """
+#     input:
+#         expand(os.path.join(config["out_dir"], "{sample}", "execute.out"),
+#                sample = samples.index)
+#     output:
+#         os.path.join(config["out_dir"], config["param_code"], config["method"],
+#         "_".join(config["param_code"], config["method"], "OUTCODE.ext"))
+#     log:
+#         os.path.join(config["local_log"], "postprocess_step_1.{sample}.log")
+#     shell:
+#         "(cat {input} {output}) &> {log}"
 
-    Note: expand() with wildcard sample gathers all samples.
 
+rule postprocess_identification:
+    """
+    A rule that produces output files for the identification challenge
+    """
+    input:
+        os.path.join(config["out_dir"], "{sample}", "execute.out"),
+        # os.path.join(config["out_dir"], config["param_code"], config["method"],
+        # "_".join(config["param_code"], config["method"], "OUTCODE.ext"))
+    output:
+        out = os.path.join(config["out_dir"],
+                           config["param_code"],
+                           config["method"],
+                           "_".join([config["param_code"],
+                                     config["method"],
+                                     "{sample}" + config["identification_output_suffix"]
+                                     ]
+                                    )
+                           )
+    params:
+        param1 = 0,
+        param2 = "PARAM_STRING"
+    threads: 4
+    container: # OR URL/TO/CONTAINER
+        os.path.join(config["envs"], "[METHOD].Dockerfile")
+    log:
+        os.path.join(config["local_log"], "postprocess_identification.{sample}.log")
+    shell:
+        """
+        (EXECUTE_COMMAND \
+        -i {input} \
+        -o {output.out} \
+        -p1 {params.param1} \
+        -p2 {params.param2}) \
+        &> {log}
+        """
+
+
+rule postprocess_quantification:
+    """
+    A rule that produces output files for the quantification challenge
+    """
+    input:
+        os.path.join(config["out_dir"], "{sample}", "execute.out"),
+        # os.path.join(config["out_dir"], config["param_code"], config["method"],
+        # "_".join(config["param_code"], config["method"], "OUTCODE.ext"))
+    output:
+        out = os.path.join(config["out_dir"], config["param_code"], config["method"],
+        "_".join([config["param_code"],
+                  config["method"],
+                  "{sample}" + config["quantification_output_suffix"]
+                  ]
+                 ))
+    params:
+        param1 = 0,
+        param2 = "PARAM_STRING"
+    threads: 4
+    container: # OR URL/TO/CONTAINER
+        os.path.join(config["envs"], "[METHOD].Dockerfile")
+    log:
+        os.path.join(config["local_log"], "postprocess_quantification.{sample}.log")
+    shell:
+        """
+        (EXECUTE_COMMAND \
+        -i {input} \
+        -o {output.out} \
+        -p1 {params.param1} \
+        -p2 {params.param2}) \
+        &> {log}
+        """
+
+rule postprocess_differential:
+    """
+    A rule that produces output files for the differential challenge
     """
     input:
         expand(os.path.join(config["out_dir"], "{sample}", "execute.out"),
-            sample = samples.index)
+               sample = samples.index)
     output:
-        os.path.join(config["out_dir"], config["param_code"], config["method"],
-        "_".join(config["param_code"], config["method"], "OUTCODE.ext"))
+        out = os.path.join(config["out_dir"],
+                           config["param_code"],
+                           config["method"],
+                           "_".join([config["param_code"],
+                                     config["method"],
+                                     config["differential_output_file"]
+                                     ]
+                                    )
+                           )
+    params:
+        param1 = 0,
+        param2 = "PARAM_STRING"
+    threads: 4
+    container: # OR URL/TO/CONTAINER
+        os.path.join(config["envs"], "[METHOD].Dockerfile")
     log:
-        os.path.join(config["local_log"], "postprocess_step_1.{sample}.log")
+        os.path.join(config["local_log"], "postprocess_differential.log")
     shell:
-        "(cat {input} {output}) &> {log}"
-
+        """
+        (EXECUTE_COMMAND \
+        -i {input} \
+        -o {output.out} \
+        -p1 {params.param1} \
+        -p2 {params.param2}) \
+        &> {log}
+        """
 
 #-------------------------------------------------------------------------------
 # How did it go?

--- a/docs/templates/snakemake/workflow/Snakefile
+++ b/docs/templates/snakemake/workflow/Snakefile
@@ -54,33 +54,7 @@ rule execute_container:
         param2 = "PARAM_STRING"
     threads: 4
     container: # OR URL/TO/CONTAINER
-        os.path.join(config["envs"], "[METHOD].Dockerfile") 
-    log:
-        os.path.join(config["local_log"], "execute.{sample}.log")
-    shell:
-        "(EXECUTE_COMMAND \
-            -i {input.bam} \
-            -o {output.out} \
-            -p1 {params.param1} \
-            -p2 {params.param2}) \
-            &> {log}"
-
-rule execute_conda:
-    """Execution rule with conda environment.
-    """
-    input:
-        bam=lambda wildcards:
-                pd.Series(
-                    samples.loc[wildcards.sample, "bam"]
-                ).values
-    output:
-        out=os.path.join(config["out_dir"], "{sample}", "execute.out")
-    params:
-        param1 = 0,
-        param2 = "PARAM_STRING"
-    threads: 4
-    conda: 
-        os.path.join(config["envs"], "[METHOD].yaml")
+        os.path.join(config["envs"], "[METHOD].Dockerfile")
     log:
         os.path.join(config["local_log"], "execute.{sample}.log")
     shell:


### PR DESCRIPTION
Partially fixes #189

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [ ] In- and output formats comply with APAeval specifications
- [ ] No parameters or file names are hardcoded
- [ ] Results, logs or other output is not commited to the repository
- [ ] I have tested my code

First attempt at updating the Snakemake template to have flags in config to switch on/off output for each challenge.

To double check I had the syntax right I made a few modifications so that the template can successfully dry run. If you're sitting in the `snakemake` directory (`docs/templates/snakemake`), you can dry run with the following steps:
```
# 1. Activate the APAeval execution conda environment
## If you haven't installed the environment yet, can do so with conda env create -f ../../../apaeval_env.yaml
$ conda activate apaeval_execution_workflows

#2. Perform dry run
$ snakemake -n -p --configfile config/config.\[METHOD\].yaml
```

I've also made updates to the README accordingly, trying to mirror the Nextflow updates as much as possible (#196 - it would probably be easier if these were on the same PR...). I tried to remove any references to conda environments as we don't want our workflows to use these anymore.

Feedback would be much appreciated :)