### PR TITLE
Ag fix vre vis

### DIFF
--- a/summary_workflows/quantification/nextflow.config
+++ b/summary_workflows/quantification/nextflow.config
@@ -68,7 +68,7 @@ params  {
 
   // other parameters
   window = 15
-  offline = o // type int; 0 for False
+  offline = 0 // type int; 0 for False
 
   //set DEFAULT_eventMark
   event_date = '2021-06-04'

--- a/summary_workflows/quantification/nextflow.config
+++ b/summary_workflows/quantification/nextflow.config
@@ -46,7 +46,7 @@ params  {
   goldstandard_dir = "$baseDir/APAeval_Q_test_data/metrics_ref_datasets"
 
   // Challenge IDs (in the same string, separated by spaces) for which the benchmark has to be performed
-  challenge_ids  = "Qx"
+  challenges_ids  = "Qx"
 
   // directory where APAeval benchmarking data is found
   assess_dir = "$baseDir/APAeval_Q_test_data/data"
@@ -68,7 +68,7 @@ params  {
 
   // other parameters
   window = 15
-  offline = 0 // type int; 0 for False
+  offline = o // type int; 0 for False
 
   //set DEFAULT_eventMark
   event_date = '2021-06-04'

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
@@ -11,7 +11,7 @@ from OEB_aggr_query import OEB_aggr_query
 # set to production link when ready
 DEFAULT_OEB_API = "https://dev-openebench.bsc.es/api/scientific/graphql"
 # Make sure to adapt accordingly in other event workflows; Here is APAeval:Quantification
-DEFAULT_bench_event_id = "OEBE0070000002" #  identification: "OEBE0070000001", differential usage: "OEBE0070000003
+DEFAULT_bench_event_id = "OEBE0070000000" # New benchmarking events (still empty): identification: "OEBE0070000001", quantification: "OEBE0070000002", differential usage: "OEBE0070000003"
 
 class Visualisations(Enum):
     """Visualisations supported for plotting.
@@ -144,10 +144,17 @@ def main():
 
         logging.debug(f"aggregation after update: {new_aggregation}")
 
-        # 2.e) Write aggregation file per challenge to local results dir
-        aggregation_file = os.path.join(challenge_dir, challenge_id + ".json")
-        with open(aggregation_file, mode='w', encoding="utf-8") as f:
-            json.dump(new_aggregation, f, sort_keys=True, indent=4, separators=(',', ': '))
+        # 2.e) Write each aggregation object to a separe file per challenge to local results dir
+        for count, aggr_object in enumerate(new_aggregation):
+            if count == 0:
+                # The first aggregation will be stored in a file name {challenge_id}.json.
+                # This will be visualised in the VRE
+                aggregation_file = os.path.join(challenge_dir, challenge_id + ".json")
+            else:
+                # The following aggregation objects will be stored in files that include the count in the name
+                aggregation_file = os.path.join(challenge_dir, challenge_id + "-" + str(count) + ".json")
+            with open(aggregation_file, mode='w', encoding="utf-8") as f:
+                json.dump(aggr_object, f, sort_keys=True, indent=4, separators=(',', ': '))
         
         # 2.f) Write assessments per challenge to local results dir
         # We have stored the assessment json objects for each challenge in the challenges dict


### PR DESCRIPTION
I had to do some small changes so that the visualisations produced by the summary workflow are visible in the VRE. The main change is that in the `results/{challenge_id}` directory there will be as many `{challenge_id}.json` files as aggregations. To be accurate, the first one will be `{challenge_id}.json` and the rest will have a number after the `{challenge_id}.json`. The VRE will visualise the results in the first JSON only, this will be fixed in the future.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [ ] In- and output formats comply with APAeval specifications
- [ ] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

