### PR TITLE
feat:several window sizes in one swf run

### DIFF
--- a/summary_workflows/quantification/APAeval_Q_test_data/data/Qx.json
+++ b/summary_workflows/quantification/APAeval_Q_test_data/data/Qx.json
@@ -1,6 +1,6 @@
 [
     {
-        "_id": "APAeval:2021-06-04_Qx_Aggregation",
+        "_id": "APAeval:2022-04-27_Qx_Aggregation_percent_matched_10nt_vs_correlation_10nt",
         "challenge_ids": [
             "Qx"
         ],
@@ -8,32 +8,27 @@
             "inline_data": {
                 "challenge_participants": [
                     {
-                        "metric_x": 0.6909599462967107,
-                        "metric_y": 0.22037462237694178,
+                        "metric_x": 0.5821652251714882,
+                        "metric_y": 0.1200645777342665,
                         "participant_id": "tool1"
                     },
                     {
-                        "metric_x": 0.7909599462967107,
-                        "metric_y": 0.32037462237694178,
-                        "participant_id": "QAPA"
-                    },
-                    {
-                        "metric_x": 0.5909599462967107,
-                        "metric_y": 0.12037462237694178,
+                        "metric_x": 0.5821652251714882,
+                        "metric_y": 0.1200645777342665,
                         "participant_id": "tool2"
                     }
                 ],
                 "visualization": {
                     "type": "2D-plot",
-                    "x_axis": "percent_matched",
-                    "y_axis": "correlation"
+                    "x_axis": "percent_matched_10nt",
+                    "y_axis": "correlation_10nt"
                 }
             }
         },
         "type": "aggregation"
     },
     {
-        "_id": "APAeval:2021-06-04_Qx_Aggregation",
+        "_id": "APAeval:2022-04-27_Qx_Aggregation_percent_matched_50nt_vs_correlation_50nt",
         "challenge_ids": [
             "Qx"
         ],
@@ -41,21 +36,70 @@
             "inline_data": {
                 "challenge_participants": [
                     {
-                        "metric_value": 0.6909599462967107,
+                        "metric_x": 0.5940375693969123,
+                        "metric_y": 0.12289112385653347,
                         "participant_id": "tool1"
                     },
                     {
-                        "metric_value": 0.7909599462967107,
-                        "participant_id": "QAPA"
-                    },
-                    {
-                        "metric_value": 0.5909599462967107,
+                        "metric_x": 0.5940375693969123,
+                        "metric_y": 0.12289112385653347,
                         "participant_id": "tool2"
                     }
                 ],
                 "visualization": {
-                    "type": "bar-plot",
-                    "metric": "MSE"
+                    "type": "2D-plot",
+                    "x_axis": "percent_matched_50nt",
+                    "y_axis": "correlation_50nt"
+                }
+            }
+        },
+        "type": "aggregation"
+    },
+    {
+        "_id": "APAeval:2022-04-27_Qx_Aggregation_MSE_10nt",
+        "challenge_ids": [
+            "Qx"
+        ],
+        "datalink": {
+            "inline_data": {
+                "challenge_participants": [
+                    {
+                        "metric_value": 0.5,
+                        "participant_id": "tool1"
+                    },
+                    {
+                        "metric_value": 0.5,
+                        "participant_id": "tool2"
+                    }
+                ],
+                "visualization": {
+                    "metric": "MSE_10nt",
+                    "type": "bar-plot"
+                }
+            }
+        },
+        "type": "aggregation"
+    },
+    {
+        "_id": "APAeval:2022-04-27_Qx_Aggregation_MSE_50nt",
+        "challenge_ids": [
+            "Qx"
+        ],
+        "datalink": {
+            "inline_data": {
+                "challenge_participants": [
+                    {
+                        "metric_value": 0.5,
+                        "participant_id": "tool1"
+                    },
+                    {
+                        "metric_value": 0.5,
+                        "participant_id": "tool2"
+                    }
+                ],
+                "visualization": {
+                    "metric": "MSE_50nt",
+                    "type": "bar-plot"
                 }
             }
         },

--- a/summary_workflows/quantification/main.nf
+++ b/summary_workflows/quantification/main.nf
@@ -15,7 +15,7 @@ if (params.help) {
 	    Run the pipeline with default parameters read from nextflow.config:
 	    nextflow run main.nf -profile docker
 	    Run with user parameters:
-	   nextflow run main.nf -profile docker --input {execution.wf.APA.prediction.file} --participant_id {tool.name} --goldstandard_dir {gold.standards.dir} --challenge_ids {analyzed.challenges} --assess_dir {benchmark.data.dir} --results_dir {output.dir}
+	   nextflow run main.nf -profile docker --input {execution.wf.APA.prediction.file} --participant_id {tool.name} --goldstandard_dir {gold.standards.dir} --challenges_ids {analyzed.challenges} --assess_dir {benchmark.data.dir} --results_dir {output.dir}
 	    Mandatory arguments:
 	        --input                 BED/TXT file with APA site information
 	        --community_id          Name or OEB permanent ID for the benchmarking community
@@ -30,7 +30,7 @@ if (params.help) {
 	        --outdir                The output directory where results for VRE will be saved
 	        --statsdir              The output directory with nextflow statistics
 	        --otherdir              The output directory where custom results will be saved (no directory inside)
-	        --window                Window size for scanning for poly(A) sites (default: 15).
+	        --windows                Window sizes for scanning for poly(A) sites (List of int).
 	        --offline               If set to 1, consolidation will be performed with local data in assess_dir only (omit to perform OEB DB query)
 	    Flags:
 	        --help                  Display this message
@@ -56,7 +56,7 @@ if (params.help) {
 	        Consolidated benchmark results directory: ${params.outdir}
 	        Nextflow statistics directory: ${params.statsdir}
 	        Directory with community-specific results: ${params.otherdir}
-	        Window size for scanning for poly(A) sites: ${params.window}
+	        Window size for scanning for poly(A) sites: ${params.windows}
 	        Offline mode: ${params.offline}
 		""".stripIndent()
 
@@ -72,7 +72,7 @@ challenge_ids = params.challenges_ids
 benchmark_data = Channel.fromPath(params.assess_dir, type: 'dir' )
 community_id = params.community_id
 event_date = params.event_date
-window = params.window
+windows = params.windows
 offline = params.offline
 
 // output 
@@ -119,7 +119,7 @@ process compute_metrics {
 	path gold_standards_dir
 	val tool_name
 	val community_id
-    val window
+    val windows
 
 	output:
 	file 'assessment.json' into assessment_out
@@ -128,7 +128,7 @@ process compute_metrics {
 	file_validated == 0
 
 	"""
-	python3 /app/compute_metrics.py -i $input_file -c $challenge_ids -g $gold_standards_dir -p $tool_name -com $community_id -o assessment.json -w $window
+	python3 /app/compute_metrics.py -i $input_file -c $challenge_ids -g $gold_standards_dir -p $tool_name -com $community_id -o assessment.json -w $windows
 	"""
 }
 

--- a/summary_workflows/quantification/nextflow.config
+++ b/summary_workflows/quantification/nextflow.config
@@ -46,7 +46,7 @@ params  {
   goldstandard_dir = "$baseDir/APAeval_Q_test_data/metrics_ref_datasets"
 
   // Challenge IDs (in the same string, separated by spaces) for which the benchmark has to be performed
-  challenge_ids  = "Qx"
+  challenges_ids  = "Qx embryonicCortex.PAPERCLIP.mm10"
 
   // directory where APAeval benchmarking data is found
   assess_dir = "$baseDir/APAeval_Q_test_data/data"
@@ -67,7 +67,7 @@ params  {
   otherdir = "${params.output}/other"
 
   // other parameters
-  window = 15
+  windows = "10 50" // type int, several values inside string separated by spaces
   offline = 0 // type int; 0 for False
 
   //set DEFAULT_eventMark

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/OEB_aggr_query/OEB_aggr_query.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/OEB_aggr_query/OEB_aggr_query.py
@@ -69,9 +69,9 @@ def query_OEB_DB(bench_event_id, challenge_name):
             logging.error("For {} got response error from graphql query: {}".format(bench_event_id, r.text))
             sys.exit(6)
         if len(data["getChallenges"]) == 0:
-            logging.error("No challenges associated to benchmarking event " + bench_event_id +
+            logging.warning("No challenges associated to benchmarking event " + bench_event_id +
                           " in OEB. Please contact OpenEBench support for information about how to open a new challenge")
-            sys.exit()
+            return
         else:
             return data.get('getChallenges')
     except Exception as e:

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
@@ -110,9 +110,10 @@ def main():
             # Load data from OEB DB
             response = OEB_aggr_query.query_OEB_DB(DEFAULT_bench_event_id, challenge_id)
 
-            # from the loaded data, create an aggregation file and write it to benchmark_dir
-            OEB_aggr_query.getOEBAggregations(response, benchmark_dir)
-
+            # If there was data in the DB, create an aggregation file and write it to benchmark_dir
+            if response:
+                OEB_aggr_query.getOEBAggregations(response, benchmark_dir)
+            # else an aggregation file will be created from template below.
 
         # 2.b) If aggregation file in benchmark_dir
         # Load aggregation file from there

--- a/summary_workflows/quantification/quantification_dockers/q_metrics/compute_metrics.py
+++ b/summary_workflows/quantification/quantification_dockers/q_metrics/compute_metrics.py
@@ -17,7 +17,7 @@ def main(args):
     participant = args.participant_name
     community = args.community_name
     out_path = args.output
-    window = args.window
+    windows = args.windows
 
     # Assuring the output path does exist
     if not os.path.exists(os.path.dirname(out_path)):
@@ -28,10 +28,10 @@ def main(args):
         except OSError as exc:
             print("OS error: {0}".format(exc) + "\nCould not create output path: " + out_path)
 
-    compute_metrics(participant_input, gold_standards_dir, challenge_ids, participant, community, out_path, window)
+    compute_metrics(participant_input, gold_standards_dir, challenge_ids, participant, community, out_path, windows)
 
 
-def compute_metrics(participant_input, gold_standards_dir, challenge_ids, participant, community, out_path, window):
+def compute_metrics(participant_input, gold_standards_dir, challenge_ids, participant, community, out_path, windows):
 
     # define array that will hold the full set of assessment datasets
     all_assessments = []
@@ -45,35 +45,39 @@ def compute_metrics(participant_input, gold_standards_dir, challenge_ids, partic
         # ground truth file
         gold_standard = os.path.join(gold_standards_dir, challenge + ".bed")
 
+        for window in windows:
+
         # METRIC: Matched sites
         ########################
-        match_with_gt_run = matchPAS.match_with_gt(participant_input,gold_standard,window)
-        merged_bed_df, n_matched_sites, n_unmatched_sites = match_with_gt_run[0], match_with_gt_run[1], match_with_gt_run[2]
-        percent_matched=n_matched_sites/(n_matched_sites+n_unmatched_sites)
-        # Key: exact name of metric as it appears in specification
-        # Value: List of [variable_holding_metric, std_err]
-        metrics["percent_matched"] = [percent_matched, 0]
+            match_with_gt_run = matchPAS.match_with_gt(participant_input,gold_standard, window)
+            merged_bed_df, n_matched_sites, n_unmatched_sites = match_with_gt_run[0], match_with_gt_run[1], match_with_gt_run[2]
+            percent_matched=n_matched_sites/(n_matched_sites+n_unmatched_sites)
+            # Key: exact name of metric as it appears in specification
+            metric_name = f"percent_matched_{window}nt"
+            # Value: List of [variable_holding_metric, std_err]
+            metrics[metric_name] = [percent_matched, 0]
 
 
-        # METRIC: correlation coffecient
-        #################################
-        correlation= matchPAS.corr_with_gt(merged_bed_df)
-        # Key: exact name of metric as it appears in specification
-        # Value: List of [variable_holding_metric, std_err]
-        metrics["correlation"] = [correlation, 0]
-                
+            # METRIC: correlation coffecient
+            #################################
+            correlation= matchPAS.corr_with_gt(merged_bed_df)
+            # Key: exact name of metric as it appears in specification
+            metric_name = f"correlation_{window}nt"
+            # Value: List of [variable_holding_metric, std_err]
+            metrics[metric_name] = [correlation, 0]
+                    
 
-        # METRIC: MSE
-        ####################
-        # Placeholder:
-        mse = 0.5
-        
-        # Key: exact name of metric as it appears in specification
-        # Value: List of [variable_holding_metric, std_err]
-        metrics["MSE"] = [mse, 0]
+            # METRIC: MSE
+            ####################
+            # Placeholder:
+            mse = 0.5
+            
+            # Key: exact name of metric as it appears in specification
+            metric_name = f"MSE_{window}nt"
+            # Value: List of [variable_holding_metric, std_err]
+            metrics[metric_name] = [mse, 0]
 
-
-        # create all assessment json objects and append them to all_assessments
+        # for each challenge, create all assessment json objects and append them to all_assessments
         for key, value in metrics.items():
             object_id = base_id + key 
             assessment_object = JSON_templates.write_assessment_dataset(object_id, community, challenge, participant, key, value[0], value[1])
@@ -91,12 +95,12 @@ if __name__ == '__main__':
     
     parser = ArgumentParser()
     parser.add_argument("-i", "--participant_data", help="execution workflow prediction outputs", required=True)
-    parser.add_argument("-c", "---challenge_ids", nargs='+', help="List of challenge ids selected by the user, separated by spaces", required=True)
+    parser.add_argument("-c", "--challenge_ids", nargs='+', help="List of challenge ids selected by the user, separated by spaces", required=True)
     parser.add_argument("-g", "--gold_standards_dir", help="dir that contains gold standard datasets for current challenge", required=True)
     parser.add_argument("-p", "--participant_name", help="name of the tool used for prediction", required=True)
     parser.add_argument("-com", "--community_name", help="name/id of benchmarking community", required=True)
     parser.add_argument("-o", "--output", help="output path where assessment JSON files will be written", required=True)
-    parser.add_argument("-w", "--window", help="window (nt) for scanning for poly(A) sites", required=True, type=int)
+    parser.add_argument("-w", "--windows", nargs='+', help="windows (nt) for scanning for poly(A) sites; several window sizes separated by spaces", required=True, type=int)
     
     args = parser.parse_args()
 


### PR DESCRIPTION
Fixes #236 
Previously only one window size was specified in config, thus, the workflow had to be re-run for different window sizes.   
    
- Provide list of window sizes in config
- loop over window sizes in `compute_metrics.py`
- create one aggregation object per plot per window size from template in `aggregation,py`

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [ ] In- and output formats comply with APAeval specifications
- [ ] No parameters or file names are hardcoded
- [ ] Results, logs or other output is not commited to the repository
- [ ] I have tested my code

