### PR TITLE
fix: incompatible col types in matchPAS

### DIFF
--- a/summary_workflows/quantification/quantification_dockers/q_metrics/matchPAS/matchPAS.py
+++ b/summary_workflows/quantification/quantification_dockers/q_metrics/matchPAS/matchPAS.py
@@ -38,7 +38,7 @@ def bedtools_window(bed1, bed2, window, reverse=False):
     if not out.stdout.decode():
         out = pd.DataFrame()
     else:
-        out = pd.read_csv(out_handle, delimiter='\t', header=None, dtype={0: str})
+        out = pd.read_csv(out_handle, delimiter='\t', header=None, dtype={0: str,6: str})
         
     # label columns
     out.rename({0: 'chrom_p', 1: 'chromStart_p', 2: 'chromEnd_p', 3: 'name_p', 4: 'score_p', 5: 'strand_p', 6: 'chrom_g', 7: 'chromStart_g', 8: 'chromEnd_g', 9: 'name_g', 10: 'score_g', 11: 'strand_g'}, axis=1, inplace=True)


### PR DESCRIPTION
In `matchPAS.py` the function `bedtools_window` returned a dataframe, where the predicted PAS chromosome was type `str`, and the ground truth chromosome `int`. Consequently, subsetting in subsequent functions was erroneous.

Fix: return both chromosome columns as type `str`.
