### PR TITLE
feat: Validation with whole gtf

### DIFF
--- a/summary_workflows/quantification/README.md
+++ b/summary_workflows/quantification/README.md
@@ -19,7 +19,7 @@ This README describes the APAeval **quantification** summary workflow. For a mor
    - input file has to be tab separated file with 6 columns
    - start and end coordinates (col 2,3) have to be int64
    - strand (col 6) has to be one of [+,-]
-   - chromosome (col 1) has to be one of [1..22,X,Y]   
+   - chromosome (col 1) has to match the ones from the genome annotation (see below `genome_dir`)
   
 - The `validated-participant-data.json` file is not used in the subsequent steps, but the workflow exits if the input file doesn't comply to the specifications of the current benchmarking event
   


### PR DESCRIPTION
Improve validation in quantification summary workflow by comparing the chromosome names from the input against the list of chromosome names from the appropriate genome annotation. 
The genome annotation is now completely read, not only the first `n` lines. The code runs not much longer, I tested it on `gencode.hg38.v38.annotation.gtf`.

Fixes #258 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

