### PR TITLE
Execution workflow: DaPars - report Format 04 BED file in workflow (per-PAS fractional relative usage)

### DIFF
--- a/execution_workflows/DaPars/README.md
+++ b/execution_workflows/DaPars/README.md
@@ -24,8 +24,7 @@ columns:
 It is important to name samples of the same condition with the exact condition name under the condition
 column in the samplesheet since samples are grouped per condition to be processed in the differential step.
 To run DaPars with test data provided for APAeval, check the path to DaPars with `pwd` and replace 
-the `path_to` in samplesheet_example_files.csv or samplesheet_example_files_identification.csv with the path 
-from the `pwd` command. 
+the `path_to` in samplesheet_example_files.csv with the path from the `pwd` command. 
 
 When using your own data and input file instead of the provided test data and sample sheet, make sure to include in the 
 input file you are using the absolute paths to the four files, with the four column names following the column
@@ -46,6 +45,7 @@ To run with singularity, comment out line 49 in Dapars/nextflow.config file `doc
 Parameters used to run the two steps of DaPars are specified in conf/modules.config file. 
 Parameters relevant to the workflow itself are:
 - `run_identification` - set to true to obtain identification challenge output. Specifying any other value will throw an error.
+- `run_relative_usage_quantification` - set to true to obtain relative expression quantification challenge output. Specifying any other value will throw an error.
 - `run_differential` - set to true to obtain differential challenge output. Specifying any other value will throw an error.
 - `output_dir` - name of the folder that the final output files are going to be in, located under Dapars/results/dapars/
 - `output_file` - name of the output file for the current run ending with .bed if running identification and .tsv if running differential
@@ -65,18 +65,24 @@ Parameters relevant to the workflow itself are:
 - Sample name for each row in the sample sheet should be unique
 - Every sample (every row) in the sample sheet will run through the identification workflow
 
+### Running the relatie usage quantification workflow
+- Set the 'run_relative_usage_quantification' parameter in conf/modules.config to true
+- Change 'relative_usage_quantification_out_suffix' parameter in conf/modules.config to 
+  the desired file suffix that ends with '.bed'
+- Sample name for each row in the sample sheet should be unique
+- Every sample (every row) in the sample sheet will run through the relative usage quantification workflow
+
 ### Running the workflow
 Once parameters have been set in conf/modules.config file, run the pilot benchmark nextflow pipeline with 
 `nextflow main.nf --input samplesheet_example_files.csv`. 
 
 ## Output & post-processing
 When using the default output_dir parameter value in conf/modules.config, DaPars store results under
-DaPars/results/dapars/challenge_outputs folder. For identification 
+DaPars/results/dapars/challenge_outputs folder. For identification and relative usage quantification
 outputs, the files have sample names as prefixes to differentiate the different runs. The differential output file 
 will stay as the name specified in modules.config file.
 
 ## Notes
-- It is not possible to obtain quantification challenge output data since the TPM value in the output file
   is provided per transcript instead of per site. Hence, this tool is not compatible for quantification
   challenge. 
 - Make sure that the input bam files have leading 'chr' in the chromosome column. Otherwise, once 

--- a/execution_workflows/DaPars/README.md
+++ b/execution_workflows/DaPars/README.md
@@ -55,37 +55,35 @@ Parameters relevant to the workflow itself are:
 ### Running the differential workflow
 - Set the 'run_differential' parameter in conf/modules.config to true
 - Change 'differential_out' parameter in conf/modules.config to the desired file name that ends with '.tsv'
-- Ensure the sample sheet contains exactly two distinct conditions in the condition column. An example input file 
+- Ensure the sample sheet contains exactly two distinct conditions in the condition column. An example input file
   is samplesheet_example_files.csv
 
 ### Running the identification workflow
 - Set the 'run_identification' parameter in conf/modules.config to true
-- Change 'identification_out_suffix' parameter in conf/modules.config to 
+- Change 'identification_out_suffix' parameter in conf/modules.config to
   the desired file suffix that ends with '.bed'
 - Sample name for each row in the sample sheet should be unique
 - Every sample (every row) in the sample sheet will run through the identification workflow
 
 ### Running the relatie usage quantification workflow
 - Set the 'run_relative_usage_quantification' parameter in conf/modules.config to true
-- Change 'relative_usage_quantification_out_suffix' parameter in conf/modules.config to 
+- Change 'relative_usage_quantification_out_suffix' parameter in conf/modules.config to
   the desired file suffix that ends with '.bed'
 - Sample name for each row in the sample sheet should be unique
 - Every sample (every row) in the sample sheet will run through the relative usage quantification workflow
 
 ### Running the workflow
-Once parameters have been set in conf/modules.config file, run the pilot benchmark nextflow pipeline with 
-`nextflow main.nf --input samplesheet_example_files.csv`. 
+Once parameters have been set in conf/modules.config file, run the pilot benchmark nextflow pipeline with
+`nextflow main.nf --input samplesheet_example_files.csv`.
 
 ## Output & post-processing
 When using the default output_dir parameter value in conf/modules.config, DaPars store results under
 DaPars/results/dapars/challenge_outputs folder. For identification and relative usage quantification
-outputs, the files have sample names as prefixes to differentiate the different runs. The differential output file 
+outputs, the files have sample names as prefixes to differentiate the different runs. The differential output file
 will stay as the name specified in modules.config file.
 
 ## Notes
-  is provided per transcript instead of per site. Hence, this tool is not compatible for quantification
-  challenge. 
-- Make sure that the input bam files have leading 'chr' in the chromosome column. Otherwise, once 
+- Make sure that the input bam files have leading 'chr' in the chromosome column. Otherwise, once
   converted to input bedgraph file for DaPars, the workflow will exit with an error
 ![](chr_prefix_error_msg.png)
    This is because DaPars checks for the leading 'chr' in the process and would error out otherwise.
@@ -94,7 +92,7 @@ will stay as the name specified in modules.config file.
 - DaPars' [documentation](http://xiazlab.org/dapars_tutorial/html/DaPars.html) specifies that a gene symbol file
   is required. The gene symbol file consists of a column of transcript id and another column of gene symbol. This
   file is then used to include the gene symbol for each row in the output file under `Gene` column, for example looks
-  like `ENSMUST00000203335.1|Wnk1|chr6|-`. However, since the differential output file requires a gene id instead of a 
+  like `ENSMUST00000203335.1|Wnk1|chr6|-`. However, since the differential output file requires a gene id instead of a
   gene symbol, this workflow extracts a gene symbol file required by DaPars by populating it with transcript id and gene id,
   such that the `Gene` column in Dapars' output file looks like `ENSMUST00000203335.1|ENSMUSG00000045962.16|chr6|-`.The gene
   id for each row can then be easily extracted for differential output file by taking the second item from the output above.

--- a/execution_workflows/DaPars/bin/check_input_params.py
+++ b/execution_workflows/DaPars/bin/check_input_params.py
@@ -7,14 +7,15 @@ import pandas as pd
 
 def parse_args(args=None):
     Description = "Check DePars input parameters"
-    Epilog = "Example usage: python check_input_params.py <IDENTIFICATION_OUT_SUFFIX> <DIFFERENTIAL_OUT>" + \
-                " <RUN_IDENTIFICATION> <RUN_DIFFERENTIAL>"
+    Epilog = "Example usage: python check_input_params.py <IDENTIFICATION_OUT_SUFFIX> <RELATIVE_USAGE_QUANTIFICATION_OUT_SUFFIX> <DIFFERENTIAL_OUT>" + \
+                " <RUN_IDENTIFICATION> <RUN_RELATIVE_USAGE_QUANTIFICATION> <RUN_DIFFERENTIAL>"
 
     parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
     parser.add_argument("IDENTIFICATION_OUT_SUFFIX", help="Name of DaPars output for the identification challenge.")
     parser.add_argument("DIFFERENTIAL_OUT", help="Name of DaPars output for the differential challenge.")
-    parser.add_argument("RUN_IDENTIFICATION", help="Can either be 'true' or 'false")
-    parser.add_argument("RUN_DIFFERENTIAL", help="Can either be 'true' or 'false")
+    parser.add_argument("RUN_IDENTIFICATION", help="Can either be 'true' or 'false'")
+    parser.add_argument("RUN_RELATIVE_USAGE_QUANTIFICATION", help="Can either be 'true' or 'false'")
+    parser.add_argument("RUN_DIFFERENTIAL", help="Can either be 'true' or 'false'")
     return parser.parse_args(args)
 
 
@@ -23,8 +24,12 @@ def main(args=None):
     if args.RUN_IDENTIFICATION == 'true':
         if not args.IDENTIFICATION_OUT_SUFFIX.endswith(".bed"):
             msg = "The identification output file name should end with '.bed'"
+            sys.exit(msg) 
+    if args.RUN_RELATIVE_USAGE_QUANTIFICATION == 'true':
+        if not args.IDENTIFICATION_OUT_SUFFIX.endswith(".bed"):
+            msg = "The relative usage quantification output file name should end with '.bed'"
             sys.exit(msg)
-    elif args.RUN_DIFFERENTIAL == 'true':
+    if args.RUN_DIFFERENTIAL == 'true':
         if not args.DIFFERENTIAL_OUT.endswith(".tsv"):
             msg = "The differential output file name should end with '.tsv'"
             sys.exit(msg)

--- a/execution_workflows/DaPars/bin/check_input_params.py
+++ b/execution_workflows/DaPars/bin/check_input_params.py
@@ -12,6 +12,7 @@ def parse_args(args=None):
 
     parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
     parser.add_argument("IDENTIFICATION_OUT_SUFFIX", help="Name of DaPars output for the identification challenge.")
+    parser.add_argument("RELATIVE_USAGE_QUANTIFICATION_OUT_SUFFIX", help="Name of DaPars output for the relative usage quantification challenge.")
     parser.add_argument("DIFFERENTIAL_OUT", help="Name of DaPars output for the differential challenge.")
     parser.add_argument("RUN_IDENTIFICATION", help="Can either be 'true' or 'false'")
     parser.add_argument("RUN_RELATIVE_USAGE_QUANTIFICATION", help="Can either be 'true' or 'false'")

--- a/execution_workflows/DaPars/bin/convert_output.py
+++ b/execution_workflows/DaPars/bin/convert_output.py
@@ -43,8 +43,8 @@ def parse_deAPA_output(file_in):
         name = '|'.join([row['Gene'].split('|')[0], chromosome, loci, orientation])
 
         # add proximal and distal apa sites in separate rows
-        outputs.add((chromosome, str(proximal_apa), str(proximal_apa+1), name, distal_relative_usage, orientation))
-        outputs.add((chromosome, str(distal_apa), str(distal_apa+1), name, proximal_relative_usage, orientation))
+        outputs.add((chromosome, str(proximal_apa), str(proximal_apa+1), name, str(proximal_relative_usage), orientation))
+        outputs.add((chromosome, str(distal_apa), str(distal_apa+1), name, str(distal_relative_usage), orientation))
 
     return outputs
         
@@ -120,7 +120,7 @@ def main(args=None):
     if args.MODE == 'identification':
         convert_to_identification(args.FILE_IN, args.FILE_OUT)
     elif args.MODE == 'relative_usage_quantification':
-       convert_to_relative_usage_quantification(arges.FILE_IN, args.FILE_OUT)
+       convert_to_relative_usage_quantification(args.FILE_IN, args.FILE_OUT)
     elif args.MODE == 'differential':
         convert_to_differential(args.FILE_IN, args.FILE_OUT)
 

--- a/execution_workflows/DaPars/bin/convert_output.py
+++ b/execution_workflows/DaPars/bin/convert_output.py
@@ -11,10 +11,43 @@ def parse_args(args=None):
 
     parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
     parser.add_argument("FILE_IN", help="DaPars output file to be converted.")
-    parser.add_argument("FILE_OUT", help="Name of DaPars output for the identification/differential challenge.")
-    parser.add_argument("MODE", help="Can either be 'differential' or 'identification")
+    parser.add_argument("FILE_OUT", help="Name of DaPars output for the identification/relative usage quantification/differential challenge.")
+    parser.add_argument("MODE", help="Can either be 'identification', 'relative_usage_quantification', or 'differential'")
     return parser.parse_args(args)
 
+
+def parse_deAPA_output(file_in):
+    outputs = set()
+    df = pd.read_csv(file_in, sep='\t')
+    for index, row in df.iterrows():
+        # keep just the gene name and orientation from Gene column
+        # e.g ENSMUST00000203335.1|ENSMUSG00000045962.16|chr6|-
+        chromosome = row['Gene'].split('|')[2]
+        orientation = row['Gene'].split('|')[3]
+        proximal_apa = int(row['Predicted_Proximal_APA'])
+        distal_relative_usage = int(row['A_1_PDUI'])
+        proximal_relative_usage = 1 - distal_relative_usage
+
+        # Get distal apa site from the Loci column
+        # e.g. chr6:119937615-119938018
+        # if orientation is +, distal apa site is the right end of the loci
+        if orientation == '+':
+            # -1 because bed file coordinate is 0 based and end exclusive
+            distal_apa = int(row['Loci'].split(':')[1].split('-')[1]) - 1
+        # else, distal apa site is the left end of the loci
+        else:
+            #TODO: remove -1 from the line below once Dapars has fixed the error of reporting 1 nt downstream of the actual annotated start
+            distal_apa = int(row['Loci'].split(':')[1].split('-')[0]) - 1
+        # generate the name for the current identified apa site
+        loci = row['Loci'].split(':')[1]
+        name = '|'.join([row['Gene'].split('|')[0], chromosome, loci, orientation])
+
+        # add proximal and distal apa sites in separate rows
+        outputs.add((chromosome, str(proximal_apa), str(proximal_apa+1), name, distal_relative_usage, orientation))
+        outputs.add((chromosome, str(distal_apa), str(distal_apa+1), name, proximal_relative_usage, orientation))
+
+    return outputs
+        
 
 def convert_to_differential(file_in, file_out):
     """
@@ -56,37 +89,29 @@ def convert_to_identification(file_in, file_out):
     :return: N/A
     """
     identification_out = open(file_out, "wt")
-    identification_outputs = set()
-    df = pd.read_csv(file_in, sep='\t')
-    for index, row in df.iterrows():
-        # keep just the gene name and orientation from Gene column
-        # e.g ENSMUST00000203335.1|ENSMUSG00000045962.16|chr6|-
-        chromosome = row['Gene'].split('|')[2]
-        orientation = row['Gene'].split('|')[3]
-        proximal_apa = int(row['Predicted_Proximal_APA'])
-
-        # Get distal apa site from the Loci column
-        # e.g. chr6:119937615-119938018
-        # if orientation is +, distal apa site is the right end of the loci
-        if orientation == '+':
-            # -1 because bed file coordinate is 0 based and end exclusive
-            distal_apa = int(row['Loci'].split(':')[1].split('-')[1]) - 1
-        # else, distal apa site is the left end of the loci
-        else:
-            #TODO: remove -1 from the line below once Dapars has fixed the error of reporting 1 nt downstream of the actual annotated start
-            distal_apa = int(row['Loci'].split(':')[1].split('-')[0]) - 1
-        # generate the name for the current identified apa site
-        loci = row['Loci'].split(':')[1]
-        name = '|'.join([row['Gene'].split('|')[0], chromosome, loci, orientation])
-
-        # add proximal and distal apa sites in separate rows
-        identification_outputs.add((chromosome, str(proximal_apa), str(proximal_apa+1), name, '.', orientation))
-        identification_outputs.add((chromosome, str(distal_apa), str(distal_apa+1), name, '.', orientation))
-
+    identification_outputs = parse_deAPA_output(file_in)
     for identification_output in identification_outputs:
+        # change the score column to '.'
+        identification_output[4] = "."
         identification_out.write("\t".join(identification_output) + "\n")
 
     identification_out.close()
+
+
+def convert_to_relative_usage_quantification(file_in, file_out):
+    """
+    This function reformats the txt deAPA output file to files for
+    relative usage quantification challenge
+    :param file_in: txt file to be reformatted
+    :param file_out: relative usage quantification challenge output file
+    :return: N/A
+    """
+    relative_usage_quantification_out = open(file_out, "wt")
+    relative_usage_quantification_outputs = parse_deAPA_output(file_in)
+    for relative_usage_quantification_output in relative_usage_quantification_outputs:
+        relative_usage_quantification_out.write("\t".join(relative_usage_quantification_output) + "\n")
+
+    relative_usage_quantification_out.close()
 
 
 def main(args=None):
@@ -94,6 +119,8 @@ def main(args=None):
     # check that mode is valid
     if args.MODE == 'identification':
         convert_to_identification(args.FILE_IN, args.FILE_OUT)
+    elif args.MODE == 'relative_usage_quantification':
+       convert_to_relative_usage_quantification(arges.FILE_IN, args.FILE_OUT)
     elif args.MODE == 'differential':
         convert_to_differential(args.FILE_IN, args.FILE_OUT)
 

--- a/execution_workflows/DaPars/bin/convert_output.py
+++ b/execution_workflows/DaPars/bin/convert_output.py
@@ -92,6 +92,7 @@ def convert_to_identification(file_in, file_out):
     identification_outputs = parse_deAPA_output(file_in)
     for identification_output in identification_outputs:
         # change the score column to '.'
+        identification_output = list(identification_output)
         identification_output[4] = "."
         identification_out.write("\t".join(identification_output) + "\n")
 

--- a/execution_workflows/DaPars/bin/convert_output.py
+++ b/execution_workflows/DaPars/bin/convert_output.py
@@ -25,7 +25,7 @@ def parse_deAPA_output(file_in):
         chromosome = row['Gene'].split('|')[2]
         orientation = row['Gene'].split('|')[3]
         proximal_apa = int(row['Predicted_Proximal_APA'])
-        distal_relative_usage = int(row['A_1_PDUI'])
+        distal_relative_usage = float(row['A_1_PDUI'])
         proximal_relative_usage = 1 - distal_relative_usage
 
         # Get distal apa site from the Loci column

--- a/execution_workflows/DaPars/conf/modules.config
+++ b/execution_workflows/DaPars/conf/modules.config
@@ -20,7 +20,8 @@ params {
     modules {
         'final_output' {
             // set run mode to either true or false
-            run_identification = true
+            run_identification = false
+	    run_relative_usage_quantification = true
             run_differential = false
 
             // Specify the final challenge result file name and destination folder
@@ -30,13 +31,16 @@ params {
 
             // output file for identification challenge should end with .bed
             identification_out_suffix = 'identification_output.bed'
+            // output file for relative usage quantification challenge should end with .bed
+            relative_usage_quantification_out_suffix = 'relative_usage_quantification_output.bed'
             // output file for differential challenge should end with .tsv
             differential_out = 'differential_output.tsv'
         }
         'files' {
             // absolute path to gtf genome file
             // e.g genome_file = '/Users/fzhuang/Desktop/APAeval/APAeval/tests/test_data/gencode_2genes_Chr_prefix.vM18.annotation.gtf'
-            genome_file = '[path_to]/../../tests/test_data/gencode_2genes_Chr_prefix.vM18.annotation.gtf'
+            //genome_file = '[path_to]/../../tests/test_data/gencode_2genes_Chr_prefix.vM18.annotation.gtf'
+            genome_file = '/home/fzhuang/new_apaeval/APAeval/execution_workflows/DaPars/../../tests/test_data/gencode_2genes_Chr_prefix.vM18.annotation.gtf'
         }
         'check_samplesheet' {
             publish_dir   = 'public_data'

--- a/execution_workflows/DaPars/conf/modules.config
+++ b/execution_workflows/DaPars/conf/modules.config
@@ -20,8 +20,8 @@ params {
     modules {
         'final_output' {
             // set run mode to either true or false
-            run_identification = false
-	    run_relative_usage_quantification = true
+            run_identification = true
+	    run_relative_usage_quantification = false
             run_differential = false
 
             // Specify the final challenge result file name and destination folder

--- a/execution_workflows/DaPars/conf/modules.config
+++ b/execution_workflows/DaPars/conf/modules.config
@@ -20,9 +20,9 @@ params {
     modules {
         'final_output' {
             // set run mode to either true or false
-            run_identification = true
-	    run_relative_usage_quantification = false
-            run_differential = false
+            run_identification = false
+	    run_relative_usage_quantification = true
+            run_differential = true
 
             // Specify the final challenge result file name and destination folder
 

--- a/execution_workflows/DaPars/conf/modules.config
+++ b/execution_workflows/DaPars/conf/modules.config
@@ -39,8 +39,7 @@ params {
         'files' {
             // absolute path to gtf genome file
             // e.g genome_file = '/Users/fzhuang/Desktop/APAeval/APAeval/tests/test_data/gencode_2genes_Chr_prefix.vM18.annotation.gtf'
-            //genome_file = '[path_to]/../../tests/test_data/gencode_2genes_Chr_prefix.vM18.annotation.gtf'
-            genome_file = '/home/fzhuang/new_apaeval/APAeval/execution_workflows/DaPars/../../tests/test_data/gencode_2genes_Chr_prefix.vM18.annotation.gtf'
+            genome_file = '[path_to]/../../tests/test_data/gencode_2genes_Chr_prefix.vM18.annotation.gtf'
         }
         'check_samplesheet' {
             publish_dir   = 'public_data'

--- a/execution_workflows/DaPars/modules/check_input_params.nf
+++ b/execution_workflows/DaPars/modules/check_input_params.nf
@@ -15,10 +15,12 @@ process CHECK_INPUT_PARAMS {
 
     script:
     run_identification = options.run_identification
+    run_relative_usage_quantification = options.run_relative_usage_quantification
     run_differential = options.run_differential
     identification_out_suffix = options.identification_out_suffix
+    relative_usage_quantification_out_suffix = options.relative_usage_quantification_out_suffix
     differential_out = options.differential_out
     """
-    check_input_params.py $identification_out_suffix $differential_out $run_identification $run_differential
+    check_input_params.py $identification_out_suffix $relative_usage_quantification_out_suffix $differential_out $run_identification $run_relative_usage_quantification $run_differential
     """
 }

--- a/execution_workflows/DaPars/modules/create_config_file.nf
+++ b/execution_workflows/DaPars/modules/create_config_file.nf
@@ -28,7 +28,7 @@ process CREATE_CONFIG_FILE {
         fdr_cutoff = options.fdr_cutoff
         pdui_cutoff = options.pdui_cutoff
         fold_change_cutoff = options.fold_change_cutoff
-        if ( run_mode == "identification" ) {
+        if ( run_mode == "identification" || run_mode == "relative_usage_quantification" ) {
             config_output = sample + "_config"
         }
         else {

--- a/execution_workflows/DaPars/modules/postprocess_relative_usage_quantification.nf
+++ b/execution_workflows/DaPars/modules/postprocess_relative_usage_quantification.nf
@@ -1,0 +1,30 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+def modules = params.modules.clone()
+// get the configs for this process
+def options = modules['final_output']
+
+/*
+    Convert DaPars output file to differential challenge file
+*/
+process POSTPROCESS_RELATIVE_USAGE_QUANTIFICATION {
+    publishDir "${params.outdir}/dapars/${options.output_dir}", mode: params.publish_dir_mode
+    container "docker.io/apaeval/dapars:latest"
+
+    input:
+    val sample
+    path output_file
+
+    output:
+    path "*"
+
+    script:
+    run_mode = "relative_usage_quantification"
+    file = "$PWD/${params.outdir}/dapars/${run_mode}/${sample}/dapars_output_All_Prediction_Results.txt"
+    relative_usage_quantification_out = "${sample}_${options.relative_usage_quantification_out_suffix}"
+    """
+    convert_output.py $file $relative_usage_quantification_out $run_mode
+    """
+}

--- a/execution_workflows/DaPars/subworkflows/run_relative_usage_quantification.nf
+++ b/execution_workflows/DaPars/subworkflows/run_relative_usage_quantification.nf
@@ -1,0 +1,53 @@
+/*
+ * Run DaPars for relative usage quantification challenge
+ */
+
+include { CREATE_CONFIG_FILE                        } from '../modules/create_config_file' addParams( options: [:] )
+include { DAPARS_MAIN                               } from '../modules/dapars_main' addParams( options: [:] )
+include { POSTPROCESS_RELATIVE_USAGE_QUANTIFICATION } from '../modules/postprocess_relative_usage_quantification' addParams( options: [:] )
+
+workflow RUN_RELATIVE_USAGE_QUANTIFICATION {
+    take:
+    ch_convert_to_bedgraph_out
+    ch_extracted_3utr_output
+
+    main:
+    /*
+     *   Prepare input channles
+     */
+    ch_convert_to_bedgraph_out
+        .map { it -> it[0] }
+        .set { ch_sample }
+
+    ch_convert_to_bedgraph_out
+        .combine( ch_extracted_3utr_output )
+        .set { ch_create_config_file_input }
+
+    /*
+     * Create config file to be used as input for step 2 of DaPars
+     */
+    CREATE_CONFIG_FILE (
+        ch_create_config_file_input,
+        "relative_usage_quantification"
+    )
+
+    /*
+     * Run step 2 of DaPars: identify the dynamic APA usages between two conditions.
+     */
+    DAPARS_MAIN (
+        CREATE_CONFIG_FILE.out.ch_dapars_input,
+        ch_sample
+    )
+
+    /*
+     * Convert DaPars output file to identification challenge output file
+     */
+    DAPARS_MAIN.out.ch_dapars_output
+        .set { ch_postprocessing_input }
+
+    POSTPROCESS_RELATIVE_USAGE_QUANTIFICATION (
+        ch_sample,
+        ch_postprocessing_input
+    )
+}
+

--- a/execution_workflows/DaPars/workflow/execute_dapars.nf
+++ b/execution_workflows/DaPars/workflow/execute_dapars.nf
@@ -32,12 +32,14 @@ def isOffline() {
 // Don't overwrite global params.modules, create a copy instead and use that within the main script.
 def modules = params.modules.clone()
 def run_identification = modules['final_output'].run_identification
+def run_relative_usage_quantification = modules['final_output'].run_relative_usage_quantification
 def run_differential = modules['final_output'].run_differential
 
-include { INPUT_CHECK } from '../subworkflows/input_check' addParams( options: [:] )
-include { PREPROCESS_FILES } from '../subworkflows/preprocess_files' addParams( options: [:] )
-include { RUN_IDENTIFICATION } from '../subworkflows/run_identification' addParams( options: [:] )
-include { RUN_DIFFERENTIAL } from '../subworkflows/run_differential' addParams( options: [:] )
+include { INPUT_CHECK                       } from '../subworkflows/input_check' addParams( options: [:] )
+include { PREPROCESS_FILES                  } from '../subworkflows/preprocess_files' addParams( options: [:] )
+include { RUN_IDENTIFICATION                } from '../subworkflows/run_identification' addParams( options: [:] )
+include { RUN_RELATIVE_USAGE_QUANTIFICATION } from '../subworkflows/run_relative_usage_quantification' addParams( options: [:] )
+include { RUN_DIFFERENTIAL                  } from '../subworkflows/run_differential' addParams( options: [:] )
 
 ////////////////////////////////////////////////////
 /* --           RUN MAIN WORKFLOW              -- */
@@ -52,6 +54,12 @@ workflow EXECUTE_DAPARS {
 
         if( run_identification ){
             RUN_IDENTIFICATION (
+                PREPROCESS_FILES.out.ch_convert_to_bedgraph_out,
+                PREPROCESS_FILES.out.ch_extracted_3utr_out
+            )
+        }
+        if( run_relative_usage_quantification ){
+            RUN_RELATIVE_USAGE_QUANTIFICATION (	
                 PREPROCESS_FILES.out.ch_convert_to_bedgraph_out,
                 PREPROCESS_FILES.out.ch_extracted_3utr_out
             )


### PR DESCRIPTION
Fixes #384

Workflow successfully ran to get relative usage quantification challenge output per sample.

Workflow:

![Screen Shot 2022-07-22 at 6 01 11 PM](https://user-images.githubusercontent.com/25573986/180574915-9d425925-20a9-43f1-a4dd-e1bc654885db.png)

Example output, the 5th column is the relative usage:
![Screen Shot 2022-07-22 at 6 22 17 PM](https://user-images.githubusercontent.com/25573986/180576114-1d414d03-80fb-47c0-87a4-ca775718482c.png)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [ ] In- and output formats comply with APAeval specifications
- [ ] No parameters or file names are hardcoded
- [ ] Results, logs or other output is not commited to the repository
- [ ] I have tested my code

