### PR TITLE
[Bug fix] Dapars: Skip 'chr' prefix check for non main chromosomes

### DIFF
--- a/execution_workflows/DaPars/bin/check_bedgraph.py
+++ b/execution_workflows/DaPars/bin/check_bedgraph.py
@@ -4,33 +4,40 @@ import sys
 import argparse
 
 def parse_args(args=None):
-	Description = "Check DaPars bedgraph input to have leading chr for all sequence regions in main chromosomes (1-22,X,Y,M). Otherwise, throw an error."
-	Epilog = "Example usage: python check_bedgraph.py <FILE_IN>"
+        Description = "Check DaPars bedgraph input to have leading chr for at least one sequence region. Otherwise, throw an error."
+        Epilog = "Example usage: python check_bedgraph.py <FILE_IN>"
 
-	parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
-	parser.add_argument("FILE_IN", help="Input bedgraph file.")
-	return parser.parse_args(args)
+        parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
+        parser.add_argument("FILE_IN", help="Input bedgraph file.")
+        return parser.parse_args(args)
 
 def check_bedgraph(file_in):
-	"""
-	This function checks that there is leading chr for all sequence regions
-	Otherwise, throw an error
-	:param file_in: bedgraph file to be checked
-	:return: N/A
-	"""
-	fin = open(file_in, "rt")
+        """
+        This function checks that there is leading chr for at least one sequence region
+        Otherwise, throw an error
+        :param file_in: bedgraph file to be checked
+        :return: N/A
+        """
+        fin = open(file_in, "rt")
+        num_no_chr = 0
+        num_line = 0
+        for line in fin:
+            num_line += 1
+            if line[0] != '#' and line[:3] != "chr":
+                num_no_chr += 1
 
-	for line in fin:
-		if line[0] != '#' and '.' not in line and line[:3] != "chr":
-			msg = "Found a row in the sample file " + file_in + " without leading 'chr' in the chromosome column for a main chromosome (1-22, X, Y, M).\n" + \
-				" Please use a file with leading 'chr' for all sequence regions in main chromosomes."
-			sys.exit(msg)
-	fin.close()
+        if num_line == num_no_chr:
+            msg = "Found all rows in the sample file " + file_in + " without leading 'chr' in the chromosome column. This will cause Dapars to error out.\n" + \
+                    " Please use a file with with at least one row with leading 'chr' in the chromosome column."
+
+            sys.exit(msg)
+
+        fin.close()
 
 def main(args=None):
-	args = parse_args(args)
-	check_bedgraph(args.FILE_IN)
+        args = parse_args(args)
+        check_bedgraph(args.FILE_IN)
 
 
 if __name__ == '__main__':
-	sys.exit(main())
+        sys.exit(main())

--- a/execution_workflows/DaPars/bin/check_bedgraph.py
+++ b/execution_workflows/DaPars/bin/check_bedgraph.py
@@ -4,7 +4,7 @@ import sys
 import argparse
 
 def parse_args(args=None):
-	Description = "Check DaPars bedgraph input to have leading chr for all sequence regions. Otherwise, throw an error."
+	Description = "Check DaPars bedgraph input to have leading chr for all sequence regions in main chromosomes (1-22,X,Y,M). Otherwise, throw an error."
 	Epilog = "Example usage: python check_bedgraph.py <FILE_IN>"
 
 	parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
@@ -22,8 +22,8 @@ def check_bedgraph(file_in):
 
 	for line in fin:
 		if line[0] != '#' and '.' not in line and line[:3] != "chr":
-			msg = "Found a row in the sample file " + file_in + " without leading 'chr' in the chromosome column.\n" + \
-				" Please use a file with leading 'chr' for all sequence regions."
+			msg = "Found a row in the sample file " + file_in + " without leading 'chr' in the chromosome column for a main chromosome (1-22, X, Y, M).\n" + \
+				" Please use a file with leading 'chr' for all sequence regions in main chromosomes."
 			sys.exit(msg)
 	fin.close()
 

--- a/execution_workflows/DaPars/bin/check_bedgraph.py
+++ b/execution_workflows/DaPars/bin/check_bedgraph.py
@@ -21,7 +21,7 @@ def check_bedgraph(file_in):
 	fin = open(file_in, "rt")
 
 	for line in fin:
-		if line[0] != '#' and line[:3] != "chr":
+		if line[0] != '#' and '.' not in line and line[:3] != "chr":
 			msg = "Found a row in the sample file " + file_in + " without leading 'chr' in the chromosome column.\n" + \
 				" Please use a file with leading 'chr' for all sequence regions."
 			sys.exit(msg)


### PR DESCRIPTION
Fixes #395 

We added a check to make sure the input files have 'chr' prefixes for all chromosomes. This was done to prevent Dapars from erroring out with a not so obvious error message when NO row contains 'chr' prefix. 

However, there are contigs in input files that by default contain to 'chr' prefix which we should allow. These row will be ignored by Dapars and we shouldn't be preventing the execution workflow from continuing by throwing an error when we encounter these rows. 

![Screen Shot 2022-08-01 at 8 23 39 PM](https://user-images.githubusercontent.com/25573986/182270827-c4180ba0-abea-4b70-aeab-65d9005e8ecf.png)


Our check should allow files containing non main chromosomes to pass without 'chr' prefix. These rows will be skipped by dapars by default. Our check should only make sure at least one row to have 'chr' prefix, as required by Dapars to not throw an error.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

