### PR TITLE
[Bug fix] Dapars: fix config file creation for relative usage quantification run mode

### DIFF
--- a/execution_workflows/DaPars/bin/create_config_file.py
+++ b/execution_workflows/DaPars/bin/create_config_file.py
@@ -47,7 +47,7 @@ def get_sample_files_differential(bedgraphs_dir):
 
 
 def get_sample_files(bedgraph_dir, bedgraph_file, run_mode):
-	if run_mode == "identification":
+	if run_mode == "identification" or run_mode == 'relative_usage_quantification':
 		return bedgraph_file, bedgraph_file
 	else:
 		return get_sample_files_differential(bedgraph_dir)


### PR DESCRIPTION
Fixes #397 

Config file creation in dapars is different depending on the run mode. Identification and relative usage quantification use the same type of config file, while differential uses a different type of config file. We added a new relative usage quantification run mode recently but this run mode is not reflected in config file creation. Instead, the differential run mode config file is created when we use relative usage quantification run mode. Hence, even though the workflow currently runs, the two parameters in the config file are incorrect:

![Screen Shot 2022-08-02 at 1 46 46 PM](https://user-images.githubusercontent.com/25573986/182441699-e53b7c63-9a6a-47f0-8761-280a6efcac59.png)

Those two parameters in the config file for relative usage quantification should have looked this:

![Screen Shot 2022-08-02 at 1 55 45 PM](https://user-images.githubusercontent.com/25573986/182441874-6f15a069-5010-410f-8c65-86b1fb6af781.png)

The fix is to add a run mode option 'relative_usage_quantification' in bin/create_config_file.py of dapars


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

