### PR TITLE
[Bug Fix] APAtrap cast output to string before parsing and avoid time out error

### DIFF
--- a/execution_workflows/APAtrap/README.md
+++ b/execution_workflows/APAtrap/README.md
@@ -13,7 +13,7 @@ to create the nextflow pipeline flow of this module
 
 ## Running APAtrap workflow
 
-## Input & pre-processing
+### Input & pre-processing
 Required files are to be specified in the input `samplesheet_example_files.csv`. Each row in the sample sheet has four
 columns:
 
@@ -34,13 +34,13 @@ input file you are using the absolute path to the file, with the four column nam
 names in `samplesheet_example_files.csv`.
 
 ### Running with Docker or Singularity
-## Docker
+#### Docker
 This workflow uses docker containers. To run with docker, make sure that docker is installed and running 
 (e.g. to ensure docker is running, run the command `docker --help` and a help message should be printed).
 Additionally, make sure that line 49 in Apatrap/nextflow.config file `docker.enabled=true` is uncommented while line
 51 `singularity.enabled=true` is commented out.
 
-## Singularity
+#### Singularity
 To run with singularity, comment out line 49 in Apatrap/nextflow.config file `docker.enabled=true` and make sure that line
 51 `singularity.enabled=true` is uncommented.
 
@@ -71,7 +71,10 @@ Parameters relevant to the workflow itself are:
   the desired file suffix that ends with '.bed'
 - In the sample sheet, at least one row is required to be provided 
 
-
+### Tuning workflow resources
+We have seen that APAtrap uses a lot of memory when running big datasets. As such, the processes use `process_big_mem` to allocate a generous amount of memory and run time. Depending on your resources availability, this can be tuned in conf/base.config. 
+Because of the amount of memory and time needed for APAtrap to run, we have to split samples by chromosome so that the workflow could complete in a reasonable amount of time. Even then, each process required around 20G. When tuning workflow resources, this should be kept in mind in case the workflow stops from memory or run time related errors.
+ 
 ### Running the workflow
 Once parameters have been set in conf/modules.config file, run the pilot benchmark nextflow pipeline with 
 `nextflow main.nf --input samplesheet_example_files.csv`. 
@@ -80,7 +83,7 @@ Note that it's recommended to delete the existing `results` folder to remove res
 This is to avoid polluting the next run with the results from the previous run when we are using the same sample name(s),
 which would likely result in an error.
 
-## Output & post-processing
+### Output & post-processing
 When using the default `output_dir` parameter value in conf/modules.config, APAtrap run results in files of the outputs 
 of the challenges located under APAtrap/results/apatrap/challenges_outputs folder.
 For identification outputs, the files have sample names as prefixes to differentiate the different runs.

--- a/execution_workflows/APAtrap/bin/convert_to_bed.py
+++ b/execution_workflows/APAtrap/bin/convert_to_bed.py
@@ -49,7 +49,7 @@ def reformat_bed(file_in, run_identification, run_quantification, identification
         # column with proximal apa sites
         # in decreasing order when strand is - e.g 119924739,119924260
         # in increasing order when strand i + e.g. 78340249,78340414
-        proximal_apa_sites = row['Predicted_APA'].split(",")
+        proximal_apa_sites = str(row['Predicted_APA']).split(",")
 
         # Write identification file
         for proximal_apa_site in proximal_apa_sites:

--- a/execution_workflows/APAtrap/conf/base.config
+++ b/execution_workflows/APAtrap/conf/base.config
@@ -38,4 +38,9 @@ process {
   withLabel:process_long {
     time   = { check_max( 20.h * task.attempt, 'time' ) }
   }
+  withLabel:process_big_mem {
+    cpus   = { check_max( 1 * task.attempt, 'cpus' ) }
+    memory = { check_max( 128.GB * task.attempt, 'memory' ) }
+    time   = { check_max( 72.h * task.attempt, 'time' ) }
+  }
 }

--- a/execution_workflows/APAtrap/modules/de_apa.nf
+++ b/execution_workflows/APAtrap/modules/de_apa.nf
@@ -14,7 +14,7 @@ process DE_APA {
         tag "$sample"
         publishDir "${params.outdir}/apatrap", mode: params.publish_dir_mode
         container "docker.io/apaeval/apatrap:latest"
-        label 'process_high'
+        label 'process_big_mem'
 
         input:
         tuple val(sample), path(de_apa_input)

--- a/execution_workflows/APAtrap/modules/de_apa.nf
+++ b/execution_workflows/APAtrap/modules/de_apa.nf
@@ -14,6 +14,7 @@ process DE_APA {
         tag "$sample"
         publishDir "${params.outdir}/apatrap", mode: params.publish_dir_mode
         container "docker.io/apaeval/apatrap:latest"
+        label 'process_high'
 
         input:
         tuple val(sample), path(de_apa_input)

--- a/execution_workflows/APAtrap/modules/identify_distal_3utr.nf
+++ b/execution_workflows/APAtrap/modules/identify_distal_3utr.nf
@@ -16,7 +16,7 @@ process IDENTIFY_DISTAL_3UTR {
         tag "$sample"
         publishDir "${params.outdir}/apatrap", mode: params.publish_dir_mode
         container "docker.io/apaeval/apatrap:latest"
-        label 'process_high'
+        label 'process_big_mem'
 
         input:
         val sample_bedgraph_files_dir

--- a/execution_workflows/APAtrap/modules/identify_distal_3utr.nf
+++ b/execution_workflows/APAtrap/modules/identify_distal_3utr.nf
@@ -16,6 +16,7 @@ process IDENTIFY_DISTAL_3UTR {
         tag "$sample"
         publishDir "${params.outdir}/apatrap", mode: params.publish_dir_mode
         container "docker.io/apaeval/apatrap:latest"
+        label 'process_high'
 
         input:
         val sample_bedgraph_files_dir

--- a/execution_workflows/APAtrap/modules/predict_apa.nf
+++ b/execution_workflows/APAtrap/modules/predict_apa.nf
@@ -15,7 +15,7 @@ process PREDICT_APA {
         tag"$sample"
         publishDir "${params.outdir}/apatrap", mode: params.publish_dir_mode
         container "docker.io/apaeval/apatrap:latest"
-        label 'process_high'
+        label 'process_big_mem'
         
         input:
         val sample_bedgraph_files_dir

--- a/execution_workflows/APAtrap/modules/predict_apa.nf
+++ b/execution_workflows/APAtrap/modules/predict_apa.nf
@@ -15,7 +15,8 @@ process PREDICT_APA {
         tag"$sample"
         publishDir "${params.outdir}/apatrap", mode: params.publish_dir_mode
         container "docker.io/apaeval/apatrap:latest"
-
+        label 'process_high'
+        
         input:
         val sample_bedgraph_files_dir
         tuple val(sample), path(reads_bedgraph_file), path(predict_apa_input)


### PR DESCRIPTION
Fixes #402 

This PR solves two errors encountered when running APAtrap with real data.

1. When converting APAtrap output to absolute TPM quantification challenge output bed file, a column containing a list of TPMs is taken and parsed by splitting by comma. This column is known to contain strings and so is directly split by comma, which has worked for most of the datasets. 

However, while running APAtrap on one of the Keratinocyte samples, one row was written as int in the APAtrap output file while the rest were written as string as expected. Hence, this row caused the workflow to error out with the following message:
![Screen Shot 2022-08-03 at 9 04 40 PM](https://user-images.githubusercontent.com/25573986/183491039-a490b592-f4e6-4953-b97b-3c3c6836cc32.png)

A solution for this is to always cast the rows to string before splitting as such:

![Screen Shot 2022-08-08 at 2 49 42 PM](https://user-images.githubusercontent.com/25573986/183491887-3bc92282-655f-4443-b53d-dec6323c237a.png)


2. APAtrap takes a long time when processing real datasets. Even when processing the samples per chromosome, it could take at least 12 hours depending on the number of samples in the sample sheet. As such, APAtrap is prone to time out errors or out of memory errors. One solution is to add the label 'process_high' in APAtrap processes to give it more time to finish running to avoid time out errors.



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

