### PR TITLE
Execution workflow: TAPAS - report Format 04 BED file in workflow (per-PAS fractional relative usage)

### DIFF
--- a/execution_workflows/TAPAS/README.md
+++ b/execution_workflows/TAPAS/README.md
@@ -6,7 +6,7 @@ The [application](https://github.com/arefeen/TAPAS) is free to download,
 and the [README documentation](https://github.com/arefeen/TAPAS#tapas-tool-for-alternative-polyadenylation-site-analysis) was used as a reference
 to create the nextflow pipeline of this module.
 
-This workflow qualifies for the APAeval **identification and quantification challenges**.
+This workflow qualifies for the APAeval **identification and relative quantification challenges**.
 
 ## Running TAPAS workflow
 
@@ -28,6 +28,8 @@ This workflow uses docker containers. To run, make sure that docker is installed
 Parameters used to run the TAPAS are specified in the nextflow.config file.
 Parameters relevant to the workflow itself are:
 - `input` - samplesheet.csv
+- `identification_bed_suffix`
+- `relative_quantification_bed_suffix`
 
 ### Running the TAPAS execution workflow
 - Download the test data [here](to be added). The current dataset is in a genomic region where there are enough reads to test TAPAS's PAS quantification functionality.

--- a/execution_workflows/TAPAS/bin/make_tapas_beds.py
+++ b/execution_workflows/TAPAS/bin/make_tapas_beds.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import sys
+
 tapa_quant_txt=open(sys.argv[1],'r')
-outbed_quant=open(sys.argv[2],'w')
+outbed_relative_quant=open(sys.argv[2],'w')
 outbed_ident=open(sys.argv[3],'w')
+
 for ln in tapa_quant_txt:
  ln=ln.strip().split('\t')
  g_id,chrom,strand=ln[0].split('NM_')[1],ln[1],ln[2]
@@ -11,14 +13,14 @@ for ln in tapa_quant_txt:
  if len(sites) == len(scores):
   for i in range(len(sites)):
    name=g_id+'_'+str(i)
-   score=scores[i]
+   relative_score=scores[i]/sum(scores)
    if strand == '+':
     chromStart=sites[i]
     chromEnd=str(int(chromStart)+1)
    elif strand == '-':
     chromEnd=sites[i]
     chromStart=str(int(chromEnd)-1)
-   outbed_quant.write('\t'.join([chrom,chromStart,chromEnd,name,score,strand])+'\n')
+   outbed_relative_quant.write('\t'.join([chrom,chromStart,chromEnd,name,relative_score,strand])+'\n')
    outbed_ident.write('\t'.join([chrom,chromStart,chromEnd,name,'.',strand])+'\n')
-outbed_quant.close()
+outbed_relative_quant.close()
 outbed_ident.close()

--- a/execution_workflows/TAPAS/bin/make_tapas_beds.py
+++ b/execution_workflows/TAPAS/bin/make_tapas_beds.py
@@ -21,7 +21,7 @@ for ln in tapa_quant_txt:
    elif strand == '-':
     chromEnd=sites[i]
     chromStart=str(int(chromEnd)-1)
-   outbed_relative_quant.write('\t'.join([chrom,chromStart,chromEnd,name,relative_score,strand])+'\n')
+   outbed_relative_quant.write('\t'.join([chrom,chromStart,chromEnd,name,str(relative_score),strand])+'\n')
    outbed_ident.write('\t'.join([chrom,chromStart,chromEnd,name,'.',strand])+'\n')
 outbed_relative_quant.close()
 outbed_ident.close()

--- a/execution_workflows/TAPAS/bin/make_tapas_beds.py
+++ b/execution_workflows/TAPAS/bin/make_tapas_beds.py
@@ -10,6 +10,7 @@ for ln in tapa_quant_txt:
  ln=ln.strip().split('\t')
  g_id,chrom,strand=ln[0].split('NM_')[1],ln[1],ln[2]
  sites,scores=ln[3].split(','),ln[4].split(',')
+ scores = [float(score) for score in scores]
  if len(sites) == len(scores):
   for i in range(len(sites)):
    name=g_id+'_'+str(i)

--- a/execution_workflows/TAPAS/nextflow.config
+++ b/execution_workflows/TAPAS/nextflow.config
@@ -15,7 +15,7 @@ params {
   // Options: skipping process(es)
   skip_differential          = false
   identification_bed_suffix  = "_tapas_identification.bed"
-  quantification_bed_suffix  = "_tapas_quantification.bed"
+  quantification_bed_suffix  = "_tapas_relative_quantification.bed"
 
   // Options: Custom config
   custom_config_version      = 'master'

--- a/execution_workflows/TAPAS/nextflow.config
+++ b/execution_workflows/TAPAS/nextflow.config
@@ -15,7 +15,7 @@ params {
   // Options: skipping process(es)
   skip_differential          = false
   identification_bed_suffix  = "_tapas_identification.bed"
-  quantification_bed_suffix  = "_tapas_relative_quantification.bed"
+  relative_quantification_bed_suffix  = "_tapas_relative_quantification.bed"
 
   // Options: Custom config
   custom_config_version      = 'master'


### PR DESCRIPTION
Fixes #426 


## Background
Thanks to @mrgazzara for the POC below:
The raw output from TAPAS's first command APA_sites_detection based on their [readme instruction on their github page](https://github.com/arefeen/TAPAS) is relative abundance, which is read count normalized by the length of the 3UTR.
![Screen Shot 2022-09-14 at 11 32 05 AM](https://user-images.githubusercontent.com/25573986/190198349-38497d95-63c5-4a50-9a18-ea2553f37937.png)

Relative usage quantification can be calculated by taking each of the relative abundance in the second to last column in the raw output (screenshot below) divided by the total relative abundance in the gene.
<img width="1270" alt="Screen Shot 2022-09-14 at 8 25 21 AM" src="https://user-images.githubusercontent.com/25573986/190199848-3c085c42-9be4-4c85-ac0a-c3ecaf507d2e.png">

## Output
I ran this PR locally following the README using a subset of P19_siControl_R1 SRR6795721 data (using [test data](https://github.com/iRNA-COSI/APAeval/pull/391#issue-1311053632) provided by @SamBryce-Smith) with read_length set to 75 (based on the [data summary table](https://docs.google.com/spreadsheets/d/1iZ-4RknIfLsfBJ8ank6w9JrkeVq0PEvoeLbtKUwghmA/edit?usp=sharing)) and gencode v38 gtf annotation file.

The workflow ran successfully
![Screen Shot 2022-09-14 at 4 27 11 PM](https://user-images.githubusercontent.com/25573986/190255741-5b47e045-795c-4b9c-b3a1-400ca2c963c9.png)

The output file for relative quantification looks like the following
![Screen Shot 2022-09-14 at 4 52 07 PM](https://user-images.githubusercontent.com/25573986/190260043-18f26c38-a5e2-4a27-8487-3b94ae99b707.png)

Which matches the raw output. Taking a couple examples, we have:
![Screen Shot 2022-09-14 at 4 55 15 PM](https://user-images.githubusercontent.com/25573986/190260580-e0c81372-89cd-447b-be36-31c4a419e20c.png)

ENSMUSG00000003721.14 only have 1 output so the relative quantification of the site is 1
ENSMUSG00000009905.5 has 3 sites with relative abundance of 0.111323,0.172196,0.0646389 and so the relative quantification of the sites are 0.3197485968291974, 0.4945916780862936, 0.1856597250845091

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

