### PR TITLE
[Bug Fix] IsoSCM identification output should be from assemble step

### DIFF
--- a/execution_workflows/IsoSCM/modules/isoscm_assemble.nf
+++ b/execution_workflows/IsoSCM/modules/isoscm_assemble.nf
@@ -4,6 +4,13 @@ include { initOptions; saveFiles; getSoftwareName } from './functions'
 params.options = [:]
 def options    = initOptions(params.options)
 
+/*
+     IsoSCM assmeble step is the first step in IsoSCM. It constructs a splice-graph exons,
+     and segment terminal exons using the constrained change-point detection procedure.
+     One of the output files contain locations of change point that can be used for
+     APAeval identification challenge. Another output file is an XML file that is used for
+     the second step, the compare step.
+*/
 process ISOSCM_ASSEMBLE {
         publishDir "${params.outdir}/isoscm/isoscm_assemble_out_dir/${sample}", mode: params.publish_dir_mode
 	container "docker.io/apaeval/isoscm:latest"
@@ -14,15 +21,19 @@ process ISOSCM_ASSEMBLE {
 
         output:
         tuple val(sample), path(assemble_out_identification_rename), emit: ch_isoscm_assemble_out
+        tuple val(sample), path(assemble_out_xml_rename), emit: ch_isoscm_assemble_out_xml
 
         script:
-        assemble_out_identification_rename = "identification_out"
-        
+        assemble_out_identification_rename = "identification_out"       
       	assemble_out_identification = sample + ".cp.gtf"
-        
+        assemble_out_xml = sample + ".assembly_parameters.xml"
+        assemble_out_xml_rename = "assemble_out_xml"
+          
         """
         java -Xmx100G -jar /IsoSCM.jar assemble -bam $aligned_bam -base $sample -s $strand -dir isoscm
-
+        
         mv isoscm/tmp/$assemble_out_identification $assemble_out_identification_rename
+        mv isoscm/$assemble_out_xml $assemble_out_xml_rename
         """
+       
 }

--- a/execution_workflows/IsoSCM/modules/isoscm_compare.nf
+++ b/execution_workflows/IsoSCM/modules/isoscm_compare.nf
@@ -1,0 +1,33 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+def options    = initOptions(params.options)
+
+/* 
+    ISOSCM compare is the second step of the tool. The splice-graphs outputs from the assemble step is used in the compare
+    step to perform joint segmentation of the terminal exons of coexpressed transcripts. This step reports the realtive usage
+    of identified change points in each sample in a tabular format
+*/
+process ISOSCM_COMPARE {
+        publishDir "${params.outdir}/isoscm/isoscm_assemble_out_dir/${sample}", mode: params.publish_dir_mode
+	container "docker.io/apaeval/isoscm:latest"
+        label 'process_high'
+
+        input:
+        tuple val(sample), path(assemble_out_xml_rename)
+
+        output:
+        tuple val(sample), path(relative_usage_quantification_out), emit: ch_isoscm_compare_out
+
+        script:
+        compare_out_relative_usage_quantification_rename = "relative_usage_quantification_out"
+        
+      	compare_out = sample + ".txt"
+        
+        """
+        java -Xmx100G -jar /IsoSCM.jar compare -base $sample -x1 $assemble_out_xml_rename -x2 $assemble_out_xml_rename
+        
+        mv compare/$compare_out $compare_out_relative_usage_quantification_rename
+        """
+}

--- a/execution_workflows/IsoSCM/modules/postprocess_identification.nf
+++ b/execution_workflows/IsoSCM/modules/postprocess_identification.nf
@@ -13,7 +13,7 @@ process POSTPROCESS_IDENTIFICATION {
         label 'process_high'
 
         input:
-        tuple val(sample), path(assemble_out_identification)
+        tuple val(sample), path(compare_output)
 
         output:
         path(output_file), emit: ch_postprocess_identification_out
@@ -23,6 +23,6 @@ process POSTPROCESS_IDENTIFICATION {
         output_file = sample + "_" + identification_out_suffix
         
         """
-        postprocess_identification.py $assemble_out_identification $output_file
+        postprocess_identification.py $compare_output $output_file
         """
  }

--- a/execution_workflows/IsoSCM/subworkflows/run_isoscm.nf
+++ b/execution_workflows/IsoSCM/subworkflows/run_isoscm.nf
@@ -5,6 +5,7 @@
 def modules = params.modules.clone()
 
 include { ISOSCM_ASSEMBLE } from '../modules/isoscm_assemble' addParams( options: [:] )
+include { ISOSCM_COMPARE } from '../modules/isoscm_compare' addParams( options: [:] )
 include { POSTPROCESS_IDENTIFICATION } from '../modules/postprocess_identification' addParams( options: [:] )
 
 workflow RUN_ISOSCM {
@@ -16,6 +17,11 @@ workflow RUN_ISOSCM {
         Run IsoSCM assemble step for each sample
      */
      ISOSCM_ASSEMBLE( ch_aligned_bam_files_dir )
+
+     /*
+        Run IsoSCM compare step for each sample
+     */
+     ISOSCM_COMPARE( ISOSCM_ASSEMBLE.out.ch_isoscm_assemble_out_xml )
 
      /*
         Get identification output file


### PR DESCRIPTION
Fixes #429 

**Background**
Currently, we get results for identification challenge from one of the output files from the _assemble_ step. Initially, this file seems to contain the identified changepoints just by looking at the content of the file.
![Screen Shot 2022-07-26 at 11 32 38 AM](https://user-images.githubusercontent.com/25573986/181048130-0b5a8dda-ed7f-420b-aafa-33b5a9c2521e.png)


But as I read further beyond the assemble step, the second step they describe is the _compare_ command. The _compare_ command "reports the differential usage of each identified change-point", which I expected to show the site usages of the same sites as the sites from the previous _assemble_ step shown in the screenshot above. But I see less and also different sites in the _compare_ step output file
![Screen Shot 2022-07-26 at 11 35 09 AM](https://user-images.githubusercontent.com/25573986/181048630-6d280fa3-6d08-43d4-957e-a2e174511ab1.png)


This led me to look more into whether we should be extracting sites for identification challenge from the _assemble_ or _compare_ step.


As additional context, the steps to run isoscm are:
1. run _assemble_ step which creates a tmp folder: isoscm/tmp/{sample}.cp.filtered.gtf
2. run _compare_ step, this requires the xml file output from assemble step for two samples, but since we're getting site usage per sample, I put the same sample twice as input to obtain the following output:
![Screen Shot 2022-07-26 at 12 18 54 PM](https://user-images.githubusercontent.com/25573986/181058458-a4aee997-b59a-4a74-8dbd-13f6b336a21e.png)

**Discussion**
Even though the first isoscm/tmp/{sample}.cp.filtered.gtf file contains changepoint locations, I'm not entirely sure we should obtain identification output sites from there since it's in a tmp folder and the github readme doesn't explain what the files in the tmp folders are--they only explained the files outside of the tmp folder from _assemble_ step i.e they explained the files from step 2 above but not files from step 1. I think the sites for identification might have to be obtained from the _compare_ step output (i.e. isoscm/compare/{sample}.txt). After reading their readme, I checked their paper and saw that in their paper, they didn't mention _assemble_ step to be where we get identified changpoints. They mentioned from "...Using the “assemble” keyword IsoSCM will assemble the mapped reads in a BAM file into a splice graph, identify nested terminal exons boundaries using the constrained segmentation procedure, and report the resulting models in GTF format....Pairwise comparison of tandem isoform usage can be performed using the “compare” keyword, which reports the relative usage of change points in each sample in a tabular format." 

**Outcome**
Hence, it sounds like the _compare_ step outputs the identified change points (or PAS) that we want to report.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [ ] In- and output formats comply with APAeval specifications
- [ ] No parameters or file names are hardcoded
- [ ] Results, logs or other output is not commited to the repository
- [ ] I have tested my code

