### PR TITLE
SWF: include parameter to filter expression

### DIFF
--- a/summary_workflows/quantification/README.md
+++ b/summary_workflows/quantification/README.md
@@ -32,6 +32,7 @@ This README describes the APAeval **(absolute) quantification** summary workflow
   - For running on OEB: The genome directory is specified in `nextflow.config`
   - For the test data, challenge `challenge_1.mm10` with ground truth file `challenge_1.mm10.bed` will use genome file `gencode.test.mm10.gtf`, because both contain `mm10` within two dots in the filename.
 > NOTE: the genome file needs to contain the same substring as the challenge. That is, challenge `[partone].[organism].[partwo].bed` requires a genome annotation file like `[partone].[organism].[partwo].gtf`, where `[organism]` starts with *mm* or *hg* (only these two currently supported). And `[partone]` and `[parttwo]` can be an aribitrary string (or empty string).
+- `tpm_threshold`: Expression filter for predictions. PolyA sites with smaller or equal transcripts per million (tpm) will be removed before metric compuatation.
 - APAeval custom functions called in [`quantification_dockers/q_metrics/compute_metrics.py`][metrics-py] are defined in `utils/apaeval`
 - The `assessments_[participant].[challenge].[event].json` file is used in the consolidation step
 

--- a/summary_workflows/quantification/main.nf
+++ b/summary_workflows/quantification/main.nf
@@ -73,6 +73,7 @@ community_id = params.community_id
 event_date = params.event_date
 windows = params.windows
 genome_dir = Channel.fromPath(params.genome_dir, type: 'dir' )
+tpm_threshold = params.tpm_threshold
 offline = params.offline
 
 // Output
@@ -131,6 +132,7 @@ process compute_metrics {
 	val community_id
 	val windows
 	path genome_dir
+	val tpm_threshold
 
 	output:
 	path "${input_file.baseName}.json", emit: ass_json
@@ -139,7 +141,7 @@ process compute_metrics {
 	validation_status == 0
 
 	"""
-	python3 /app/compute_metrics.py -i $input_file -c $challenge_ids -g $gold_standards_dir -p $tool_name -com $community_id -o "${input_file.baseName}.json" -w $windows --genome_dir $genome_dir
+	python3 /app/compute_metrics.py -i $input_file -c $challenge_ids -g $gold_standards_dir -p $tool_name -com $community_id -o "${input_file.baseName}.json" -w $windows --genome_dir $genome_dir --tpm_threshold $tpm_threshold
 	"""
 }
 
@@ -198,7 +200,8 @@ workflow {
 		tool_name,
 		community_id,
 		windows,
-		genome_dir
+		genome_dir,
+		tpm_threshold
 		)
 	assessments = compute_metrics.out.ass_json.collect()
 

--- a/summary_workflows/quantification/nextflow.config
+++ b/summary_workflows/quantification/nextflow.config
@@ -90,6 +90,7 @@ params  {
   // other parameters
   windows = "100 50 10" // type int, several values inside string separated by spaces. The first value is used for relative PAS usage calculation.
   genome_dir = "$goldstandard_dir/genomes" // Must contain a .gtf file with same substring as in challenge_ids, e.g. test.genome.mm10_test.gtf
+  tpm_threshold = 0 // Expression filter for predictions. PolyA sites with smaller or equal transcripts per million (tpm) will be removed before metric compuatation.
   offline = 0 // type int; 0 for False
 
   //set DEFAULT_eventMark


### PR DESCRIPTION
Fixes #424 

The filtering happens at two stages: 

- matched sites are filtered for prediction scores > `tpm_threshold`. This will be used for various metrics, including true positives and the various correlation metrics. 
- prediction sites are filtered for scores > `tpm_threshold`. This will be used for computing false positives.

Let me know if this makes sense in both cases. 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

