### PR TITLE
[BugFix] QAPA error converting string "NA" to float when calculating PPAU

### DIFF
--- a/execution_workflows/QAPA/bin/make_quant_bed.py
+++ b/execution_workflows/QAPA/bin/make_quant_bed.py
@@ -9,7 +9,12 @@ qapa_quant_bed_tpm=open(sys.argv[3],'w')
 
 for ln in qapa_results_file:
  ln=ln.strip().split('\t')
- ppau_fraction=float(ln[12])/100.0
+ # if the ppau value is NA, don't calculate ppau fraction
+ if ln[12] == "NA":
+  ppau_fraction = ln[12]
+ # if ppau is not NA, calculate ppau fraction by dividing by 100
+ else:
+  ppau_fraction=float(ln[12])/100.0
  if ln[7] == '+':
   chromStart,chromEnd=str(int(ln[9])-1),ln[9]
  elif ln[7] == '-':


### PR DESCRIPTION
Fixes #436 

Thanks to @mrgazzara for reporting the bug!

**Problem**
An error occurred when running QAPA on Mayr data stating that string "NA" could not be converted to float in PPAU calculation.

<img width="1084" alt="Screen Shot 2022-10-06 at 7 33 22 PM" src="https://user-images.githubusercontent.com/25573986/194437055-64767d36-c788-4038-a9f1-985c46d2497a.png">

**Solution**
A solution to this is when the PPAU value is NA, we leave the string as is. Otherwise, we convert PPAU value to float when calculating PPAU fraction.

The solution works 
<img width="1078" alt="Screen Shot 2022-10-06 at 7 41 40 PM" src="https://user-images.githubusercontent.com/25573986/194437816-7b45622a-ec2a-4fa3-b560-bcf348a5ecb7.png">


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

