### PR TITLE
Bug: GETUTR file not found error in postprocessing step when using huge sample file

### DIFF
--- a/execution_workflows/GETUTR/modules/getutr_process.nf
+++ b/execution_workflows/GETUTR/modules/getutr_process.nf
@@ -7,7 +7,7 @@ def options    = initOptions(params.options)
 
 process GETUTR_PROCESS {
         container "docker.io/apaeval/getutr:latest"
-        label 'process_high'
+        label "process_high"
 
         input:
         tuple val(sample), path(bam), path(gtf)

--- a/execution_workflows/GETUTR/modules/getutr_process.nf
+++ b/execution_workflows/GETUTR/modules/getutr_process.nf
@@ -6,17 +6,19 @@ params.options = [:]
 def options    = initOptions(params.options)
 
 process GETUTR_PROCESS {
-        publishDir "${params.outdir}/getutr", mode: params.publish_dir_mode
         container "docker.io/apaeval/getutr:latest"
-        label "process_high"
+        label 'process_high'
 
         input:
         tuple val(sample), path(bam), path(gtf)
 
         output:
-        path "*.bed", emit: ch_getutr_output
+        tuple val(sample), path(getutr_output), emit: ch_getutr_output
 
         script:
+        // GETUTR outputs two file .PAVA.cps.2.0.0.bed and PAVA.smoothed.2.0.0.bed
+        // We only need PAVA.cps.2.0.0.bed
+        getutr_output = "${sample}.PAVA.cps.2.0.0.bed"
         """
         python2.7 /software/GETUTR/getutr.py -r $gtf -i $bam -o $sample
         """

--- a/execution_workflows/GETUTR/modules/postprocessing_identification.nf
+++ b/execution_workflows/GETUTR/modules/postprocessing_identification.nf
@@ -4,27 +4,23 @@ include { initOptions; saveFiles; getSoftwareName } from './functions'
 params.options = [:]
 def modules = params.modules.clone()
 // get the configs for this process
-def options = modules['final_output']
 
 /*
-    Convert GETUTR output file to differential challenge file
+    Convert GETUTR output file to identification challenge file
 */
 process POSTPROCESSING_IDENTIFICATION {
     publishDir "${params.outdir}/getutr", mode: params.publish_dir_mode
     container "docker.io/apaeval/getutr:latest"
 
     input:
-    val sample
+    tuple val(sample), path(getutr_output)
+ 
+    output:
     path "*"
 
     script:
-    file1 = "$PWD/${params.outdir}/getutr/${sample}.PAVA.cps.2.0.0.bed"
-    file2 = "$PWD/${params.outdir}/getutr/${sample}.PAVA.smoothed.2.0.0.bed" // dont need this one
-    identification_output = "$PWD/${params.outdir}/getutr/${sample}_identification_output.bed" // dont need this one
+    identification_output = "${sample}_identification_output.bed"
     """
-    awk '{if (\$1=="track") print \$0; else print \$1, \$2, \$3, \$4, ".", \$6}' ${file1} > temp1
-    mv temp1 ${identification_output}
-    rm ${file1}
-    rm ${file2}
+    awk '{if (\$1=="track") print \$0; else print \$1, \$2, \$3, \$4, ".", \$6}' ${getutr_output} > ${identification_output}
     """
 }

--- a/execution_workflows/GETUTR/subworkflows/run_getutr.nf
+++ b/execution_workflows/GETUTR/subworkflows/run_getutr.nf
@@ -20,10 +20,6 @@ workflow RUN_GETUTR {
     GETUTR_PROCESS.out.ch_getutr_output
         .set { ch_postprocessing_input }
 
-    ch_sample
-        .map { it -> it[0] }
-        .set { sample_only }
-
-    POSTPROCESSING_IDENTIFICATION(sample_only, ch_postprocessing_input)
+    POSTPROCESSING_IDENTIFICATION(ch_postprocessing_input)
 }
 


### PR DESCRIPTION
Fixes #438

**Background**
When running GETUTR with a huge sample file, postprocess step will encounter a file not found error from DaPars. An example of the error message is below:
<img width="957" alt="Screen Shot 2022-10-13 at 1 33 30 PM" src="https://user-images.githubusercontent.com/25573986/195917236-731d696e-1c8d-45ce-9ce4-5f04e5ddf592.png">

This issue is however never encountered when using our test files that are small.

**Problem**
After investigating the workflow, the issue seems to be that getutr_process.nf publishes the file from GETUTR to a location in the output directory. The postprocessing step then reads from the file published to the output directory. When the output is big, the file publishing would take a little longer, but the workflow would already move on to the next process which is postprocessing step. Hence, the file is not found because it wasn't done being created.

**Solution**
One way to solve this is to avoid reading from a published file because that would take some time. Instead, we could read the file from the output channel of the previous process.

This solution works and the workflow finishes without error:
![Screen Shot 2022-10-14 at 2 38 58 PM](https://user-images.githubusercontent.com/25573986/195917731-3ced273f-998d-40c5-9114-7581952eb176.png)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

