### PR TITLE
Execution workflow update: IsoSCM doesn't run with reverse_forward and unstranded combination

### DIFF
--- a/execution_workflows/IsoSCM/README.md
+++ b/execution_workflows/IsoSCM/README.md
@@ -34,8 +34,8 @@ columns:
 
 - sample: name of the sample (e.g control_replicate1)
 - bam: absolute path to BAM input file for the sample 
-- strand: the strandedness of the data, can be 'reverse_forward' or 'unstranded'
-- read_type: whether the sample contains paired-end or single-end reads, can be 'paired' or 'single'
+- strand: the strandedness of the data, can be 'reverse_forward' or 'unstranded'. reverse_forward is only for paired-end reads, while unstranded can be for both single and paired-end reads
+- read_type: whether the sample contains paired-end or single-end reads, can be 'paired' or 'single'. If sample contains single-end reads, strand needs to be set to unstranded otherwise the tool will error out
 Make sure each sample name is unique.
 
 To run IsoSCM with test data provided for APAeval, check the path to IsoSCM with `pwd` and replace 

--- a/execution_workflows/IsoSCM/bin/check_samplesheet.py
+++ b/execution_workflows/IsoSCM/bin/check_samplesheet.py
@@ -75,15 +75,20 @@ def check_samplesheet(file_in, file_out):
                     print_error("bam contains spaces!", 'Line', line)
                 if not bam.endswith(".bam"):
                     print_error("bam does not have extension 'bam'", 'Line', line)
+            
             ## Check the strand
             if strand:
                 if strand != "reverse_forward" and strand != "unstranded":
                     print_error("strand can only be either reverse_forward or unstranded, received " + strand, 'Line', line)
-
+            
             ## Check the read_type
             if read_type:
                 if read_type != "single" and read_type != "paired":
                     print_error("read_type can only be either single or paired, received " + read_type, 'Line', line)
+
+            # Check strand and read_type combination
+            if strand == "reverse_forward" and read_type == "single":
+                print_error("For single end read, strand should be set to unstranded to avoid error thrown by the tool")
 
             ## Create sample mapping dictionary = {group: {replicate : [ barcode, input_file, genome, gtf, is_transcripts ]}}
             sample_info = [ sample, bam, strand, read_type]


### PR DESCRIPTION
Fixes #440 

**Background**
IsoSCM allows for two settings in terms for strandedness--unstranded and reverse_forward. It wasn't explicitly stated in the tool's README but when we have single end reads with reverse/forward strandedness, we can't set IsoSCM's strandedness to be reverse_forward. This will cause an error. Hence, we need to add checks in the workflow to prevent users from using the wrong combination of inputs and having to wait for the tool to run before encountering this error.

**Solution**
Add a parameter check when reading the samplesheet to never have reverse_forward and single read combination

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

