### PR TITLE
Ewf bugfix: Change GETUTR challenge output file delimiter from space to tab

### DIFF
--- a/execution_workflows/GETUTR/modules/postprocessing_identification.nf
+++ b/execution_workflows/GETUTR/modules/postprocessing_identification.nf
@@ -14,13 +14,13 @@ process POSTPROCESSING_IDENTIFICATION {
 
     input:
     tuple val(sample), path(getutr_output)
- 
+
     output:
     path "*"
 
     script:
     identification_output = "${sample}_identification_output.bed"
     """
-    awk '{if (\$1=="track") print \$0; else print \$1, \$2, \$3, \$4, ".", \$6}' ${getutr_output} > ${identification_output}
+    awk 'BEGIN {OFS="\t"} {if (\$1=="track") print \$0; else print \$1,\$2,\$3,\$4,".",\$6}' ${getutr_output} > ${identification_output}
     """
 }


### PR DESCRIPTION
Fixes a bug spotted by @dominikburri - GETUTR's identification output BED files were delimited by spaces not tabs, which doesn't fit the BED convention. I added a quick fix to the awk command to directly set the output delimiter to tab with `{OFS="\t"}`
e.g.
```
    script:
    identification_output = "${sample}_identification_output.bed"
    """
    awk 'BEGIN {OFS="\t"} {if (\$1=="track") print \$0; else print \$1,\$2,\$3,\$4,".",\$6}' ${getutr_output} > ${identification_output}
    """
}
```

I ran with APAeval 2 gene test data and got tab-delimited output.
![image](https://user-images.githubusercontent.com/49978382/199288058-c3b79bbc-2a9b-49e4-9159-6da88402a98b.png)


 In example below I got vim to show hidden characters, with tabs denoted by '^I'.
![image](https://user-images.githubusercontent.com/49978382/199287832-f825ac22-a9d2-430f-818f-d67b504cb83d.png)

If you also do a quick `head` on the output files you can also see that they appear to be tab-separated (top) vs the files generated with existing code (bottom)

![image](https://user-images.githubusercontent.com/49978382/199288286-35044758-e622-49f0-9bed-d60bcdc85f30.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

