### PR TITLE
Fix: utils metrics2tsv to work for identification event

### DIFF
--- a/utils/metrics_json2tsv/metrics_json2tsv.py
+++ b/utils/metrics_json2tsv/metrics_json2tsv.py
@@ -60,8 +60,10 @@ def main():
     # Split metric_id to get window size and return type
     # First get metric name in new col
     metrics_df[['metric','temp']] = metrics_df['metrics.metric_id'].str.split(':', 1, expand=True)
+
     # Now swap return type and window (neccessary to get NA if return type is missing)
-    metrics_df['temp'] = metrics_df['temp'].apply(lambda x: str_swap(x,':'))
+    metrics_df['temp'] = metrics_df['temp'].apply(lambda x: str_swap(x,':') if x is not None else "nt:all" )
+
     # type and window in new col
     metrics_df[['window_size', 'site_set']] = metrics_df['temp'].str.split(':', 1, expand=True)
     # drop obsolete cols


### PR DESCRIPTION
When splitting metrics ids and expanding columns the script failed for identification jsons because some metrics don't contain window sizes, and there are no site sets in identification (script was written for AbsQuant files).   
Quick fix here: Replace `None` with mock value. Column `site_set` will contain mostly "NA", but "all" for metric AUC. This is necessary because pandas won't expand cols if there are only "NA" values.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [ ] In- and output formats comply with APAeval specifications
- [ ] No parameters or file names are hardcoded
- [ ] Results, logs or other output is not commited to the repository
- [ ] I have tested my code

