### PR TITLE
Fix: scikit-learn instead of sklearn

### DIFF
--- a/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
+++ b/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
@@ -1,7 +1,7 @@
 pandas
 jsonschema
 scipy
-sklearn
+scikit-learn
 pyranges
 git+https://github.com/iRNA-COSI/APAeval.git@main#egg=apaeval&subdirectory=utils/apaeval
 git+https://github.com/iRNA-COSI/APAeval.git@main#egg=main&subdirectory=summary_workflows/JSON_templates


### PR DESCRIPTION
Compute_metrics.py inside the i_metrics docker image failed because module sklearn not available.(had worked before)    

Fix: scikit-learn instead sklearn in requirements.txt

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [ ] In- and output formats comply with APAeval specifications
- [ ] No parameters or file names are hardcoded
- [ ] Results, logs or other output is not commited to the repository
- [ ] I have tested my code

