### PR TITLE
Execution workflow: GETUTR - report Format 04 BED file in workflow (per-PAS fractional relative usage)

### DIFF
--- a/execution_workflows/GETUTR/Dockerfile
+++ b/execution_workflows/GETUTR/Dockerfile
@@ -10,6 +10,7 @@ RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 RUN python2.7 get-pip.py
 RUN pip2 install numpy
 RUN pip2 install 'rpy2<2.9.0'
+RUN pip2 install pandas
 RUN mkdir /software
 WORKDIR /software
 RUN wget -c http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/gtfToGenePred

--- a/execution_workflows/GETUTR/README.md
+++ b/execution_workflows/GETUTR/README.md
@@ -1,7 +1,7 @@
 # GETUTR Nextflow execution workflow
 This is the initial version of the [GETUTR](http://big.hanyang.ac.kr/GETUTR/manual.htm) execution workflow.
 
-## Input and Output
+## Input
 The input is a samplesheet.csv file:
 
 ```
@@ -13,10 +13,23 @@ sample2,/full/path/sample2.bam
 
 For each sample line, the results are stored in `results/$sample.PAVA.cps.2.0.0.bed` and `results/$sample.PAVA.smoothed.2.0.0.bed`. For the Mayr samples, the memory requirements are high, around 128GB for the larger samples (bam file of 8GB).
 
+## Output
+GETUTR outputs identification and relative usage quantification bed files.
+
+## Parameters
+Parameters used to run GETUTR are specified in conf/modules.config file. Parameters relevant to the workflow are:
+- `run_identification` - set to true to obtain identification challenge output.
+- `run_relative_usage_quantification` - set to true to obtain relative usage quantification challenge output.
+- `identification_out_suffix` - suffix of the output file(s) for the current run ending with .bed when running identification,
+                                the prefix will be the different sample names obtained from the sample column in the sample sheet
+- `relative_usage_quantification_out_suffix` - suffix of the output file(s) for the current run ending with .bed when running relative usage quantification,
+                                the prefix will be the different sample names obtained from the sample column in the sample sheet
+
 ## Running
 
 Running the nextflow once you define the `samplesheet.csv` is a one line command:
 
-`nextflow main.nf --input samplesheet.csv --gtf /full/path/genome.gtf -profile docker`
-
+`nextflow main.nf --input samplesheet.csv --gtf /full/path/genome.gtf -profile docker` to run with docker
+or
+`nextflow main.nf --input samplesheet.csv --gtf /full/path/genome.gtf -profile singularity` to run with singularity
 Voila

--- a/execution_workflows/GETUTR/bin/postprocess_relative_quantification.py
+++ b/execution_workflows/GETUTR/bin/postprocess_relative_quantification.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+
+
+def parse_args(args=None):
+    description = "Reformat GETUTR output bed file into the output file of relative usage quantification challenges"
+    epilog = "Example usage: python convert_to_bed.py <FILE_IN> <RUN_IDENTIFICATION> <RELATIVE_USAGE_QUANTIFICATION_OUT>"
+
+    parser = argparse.ArgumentParser(description=description, epilog=epilog)
+    parser.add_argument("FILE_IN", help="Input deAPA output txt file.")
+    parser.add_argument("RELATIVE_USAGE_QUANTIFICATION_OUT", help="Name of output file for relative usage quantification challenge")
+    return parser.parse_args(args)
+
+
+def reformat_bed(file_in, relative_usage_quantification_out):
+    """
+    This function reformats GETUTR bed output file to file for relative quantification challenges
+    :param file_in: bed file to be reformatted
+    :param relative_usage_quantification_out: relative usage quantification output file name
+    :return: N/A
+    """
+
+    relative_usage_quantification_outputs = []
+    
+    outfile = open(relative_usage_quantification_out, "w")
+
+    with open(file_in) as f:
+        curr_transcript = ''
+        count = 0
+        for line in f:
+            chrom = line.split('\t')[0]
+            start = line.split('\t')[1]
+            end = line.split('\t')[2]
+            transcript = line.split('\t')[3]
+            if curr_transcript == transcript:
+                count += 1
+            else:
+                curr_transcript = transcript
+                count = 0
+            name = transcript + '_' + str(count)
+            score = line.split('\t')[4]
+            strand = line.split('\t')[5]
+            row = [chrom, start, end, name, score, strand]
+            outfile.write("\t".join(row))
+    outfile.close()
+
+def main(args=None):
+    args = parse_args(args)
+    reformat_bed(args.FILE_IN, args.RELATIVE_USAGE_QUANTIFICATION_OUT)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/execution_workflows/GETUTR/conf/modules.config
+++ b/execution_workflows/GETUTR/conf/modules.config
@@ -25,9 +25,14 @@ params {
             publish_files = true
             publish_dir   = 'results'
         }
-        'make_differential_tsv' {
-            publish_files = false
-        }
+        'final_outputs' {
+            // run modes can either be true or false
+	    run_identification = true
+	    run_relative_usage_quantification = true
 
+            // specify the output file names for each challenge
+            identification_out_suffix = '.01.bed'
+            relative_usage_quantification_out_suffix = '.04.bed'
+        }
     }
 }

--- a/execution_workflows/GETUTR/modules/postprocessing_identification.nf
+++ b/execution_workflows/GETUTR/modules/postprocessing_identification.nf
@@ -3,7 +3,7 @@ include { initOptions; saveFiles; getSoftwareName } from './functions'
 
 params.options = [:]
 def modules = params.modules.clone()
-// get the configs for this process
+def inputs = modules['final_outputs']
 
 /*
     Convert GETUTR output file to identification challenge file
@@ -19,7 +19,7 @@ process POSTPROCESSING_IDENTIFICATION {
     path "*"
 
     script:
-    identification_output = "${sample}_identification_output.bed"
+    identification_output = sample + inputs.identification_out_suffix
     """
     awk 'BEGIN {OFS="\t"} {if (\$1=="track") print \$0; else print \$1,\$2,\$3,\$4,".",\$6}' ${getutr_output} > ${identification_output}
     """

--- a/execution_workflows/GETUTR/modules/postprocessing_relative_quantification.nf
+++ b/execution_workflows/GETUTR/modules/postprocessing_relative_quantification.nf
@@ -3,7 +3,7 @@ include { initOptions; saveFiles; getSoftwareName } from './functions'
 
 params.options = [:]
 def modules = params.modules.clone()
-// get the configs for this process
+def inputs = modules['final_outputs']
 
 /*
     Convert GETUTR output file to relative quantification challenge file
@@ -19,7 +19,7 @@ process POSTPROCESSING_RELATIVE_QUANTIFICATION {
     path "*"
 
     script:
-    relative_quantification_output = "${sample}_relative_quantification_output.bed"
+    relative_quantification_output = sample + inputs.relative_usage_quantification_out_suffix
     """
     postprocess_relative_quantification.py ${getutr_output} ${relative_quantification_output}
     """

--- a/execution_workflows/GETUTR/modules/postprocessing_relative_quantification.nf
+++ b/execution_workflows/GETUTR/modules/postprocessing_relative_quantification.nf
@@ -1,0 +1,26 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+def modules = params.modules.clone()
+// get the configs for this process
+
+/*
+    Convert GETUTR output file to relative quantification challenge file
+*/
+process POSTPROCESSING_RELATIVE_QUANTIFICATION {
+    publishDir "${params.outdir}/getutr", mode: params.publish_dir_mode
+    container "docker.io/apaeval/getutr:latest"
+
+    input:
+    tuple val(sample), path(getutr_output)
+
+    output:
+    path "*"
+
+    script:
+    relative_quantification_output = "${sample}_relative_quantification_output.bed"
+    """
+    postprocess_relative_quantification.py ${getutr_output} ${relative_quantification_output}
+    """
+}

--- a/execution_workflows/GETUTR/subworkflows/run_getutr.nf
+++ b/execution_workflows/GETUTR/subworkflows/run_getutr.nf
@@ -4,6 +4,7 @@
 
 include { GETUTR_PROCESS  } from '../modules/getutr_process' addParams( options: [:] )
 include { POSTPROCESSING_IDENTIFICATION } from '../modules/postprocessing_identification' addParams( options: [:] )
+include { POSTPROCESSING_RELATIVE_QUANTIFICATION } from '../modules/postprocessing_relative_quantification' addParams( options: [:] )
 
 workflow RUN_GETUTR {
     take:
@@ -21,5 +22,7 @@ workflow RUN_GETUTR {
         .set { ch_postprocessing_input }
 
     POSTPROCESSING_IDENTIFICATION(ch_postprocessing_input)
+
+    POSTPROCESSING_RELATIVE_QUANTIFICATION(ch_postprocessing_input)
 }
 

--- a/execution_workflows/GETUTR/subworkflows/run_getutr.nf
+++ b/execution_workflows/GETUTR/subworkflows/run_getutr.nf
@@ -2,6 +2,10 @@
  * RUN GETUTR
  */
 
+def modules = params.modules.clone()
+def run_identification = modules['final_outputs'].run_identification
+def run_relative_usage_quantification = modules['final_outputs'].run_relative_usage_quantification
+
 include { GETUTR_PROCESS  } from '../modules/getutr_process' addParams( options: [:] )
 include { POSTPROCESSING_IDENTIFICATION } from '../modules/postprocessing_identification' addParams( options: [:] )
 include { POSTPROCESSING_RELATIVE_QUANTIFICATION } from '../modules/postprocessing_relative_quantification' addParams( options: [:] )
@@ -21,8 +25,13 @@ workflow RUN_GETUTR {
     GETUTR_PROCESS.out.ch_getutr_output
         .set { ch_postprocessing_input }
 
-    POSTPROCESSING_IDENTIFICATION(ch_postprocessing_input)
+    if ( run_identification ) {
+    	POSTPROCESSING_IDENTIFICATION(ch_postprocessing_input)
+    }
 
-    POSTPROCESSING_RELATIVE_QUANTIFICATION(ch_postprocessing_input)
+    if ( run_relative_usage_quantification ) {
+        POSTPROCESSING_RELATIVE_QUANTIFICATION(ch_postprocessing_input)
+    }
 }
+
 


### PR DESCRIPTION
Fixes #450 

**Background**
GETUTR outputs 2 files - smoothed 3' UTR and poly(A) cleavage sites with relative usage per site. For identification challenge, we extract the output file containing poly(A) cleavage sites. An example of the output file is below:
![Screen Shot 2022-11-08 at 1 31 32 PM](https://user-images.githubusercontent.com/25573986/200646665-49886e7f-f567-4421-9d20-c956c3ca4a06.png)

**Solution**
For relative quantification challenge, we could take the column containing relative usage per site. We want a relative quantification challenge output file that looks like the following:
<img width="823" alt="Screen Shot 2022-11-08 at 1 35 54 PM" src="https://user-images.githubusercontent.com/25573986/200647482-94f76488-fea7-4f50-a46c-cea73ee9e5f0.png">
The name column includes a numbered suffix for each site to indicate the number of sites in each transcript.

Big thanks to @mrgazzara for the POC of this issue!

**Results**
After incorporating relative quantification workflow, the new execution workflow runs successfully:
![Screen Shot 2022-11-08 at 1 41 10 PM](https://user-images.githubusercontent.com/25573986/200648443-45cbde5c-89a8-4f65-a526-b727a204ed73.png)
The output files now contain both identification and relative quantification challenge output files:
![Screen Shot 2022-11-08 at 1 41 30 PM](https://user-images.githubusercontent.com/25573986/200648502-19387544-5bdf-42ea-ad34-f59baed6a2f0.png)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

