### PR TITLE
fix: swf-ident: reduce memory and time consumption 

### DIFF
--- a/summary_workflows/identification/identification_dockers/i_metrics/compute_metrics.py
+++ b/summary_workflows/identification/identification_dockers/i_metrics/compute_metrics.py
@@ -155,18 +155,17 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant, communi
         metrics["AUC"] = [pr_auc, 0] 
 
         # METRICS:Percentage of genes with correctly identified number of PAS
-        pas_per_gene_GT = [apa.find_pas_genes(gene, GT) for i, gene in genome.iterrows()]
-        # count number of PAS per gene (i.e. row) in GT
-        counts_GT = [len(np.where(pas)[0]) for pas in pas_per_gene_GT]
+        # count number of PAS per gene (i.e. row) in GT; stored as gene-ordered list.
+        counts_GT = [len(np.where(apa.find_pas_genes(gene, GT))[0]) for i, gene in genome.iterrows()]
         # Number of genes with > 0 PAS
         genes_nonzero_PAS = np.array([x > 0 for x in counts_GT], dtype=bool)
         n_genes_nonzero_PAS = len(np.where(genes_nonzero_PAS)[0])
 
-        # count number of PAS per gene (i.e. row) in PD
+        # count number of PAS per gene (i.e. row) in PD; stored as gene-ordered list.
+        # first remove duplicates and rename columns to GT names.
         PDwcn = PD[PD_cols].drop_duplicates()
         PDwcn.columns = GT_cols
-        pas_per_gene_PD = [apa.find_pas_genes(gene, PDwcn) for i, gene in genome.iterrows()]
-        counts_PD = [len(np.where(pas)[0]) for pas in pas_per_gene_PD]
+        counts_PD = [len(np.where(apa.find_pas_genes(gene, PDwcn))[0]) for i, gene in genome.iterrows()]
         # Number of genes with identical number of polyA sites in PD and GT and > 0 PAS
         genes_identical_PAS = np.array([counts_PD[i] == counts_GT[i] for i in range(len(counts_GT))], dtype=bool)
         # Number of genes with identical PAS between GT and PD AND minimum 1 PAS,


### PR DESCRIPTION
When dealing with big files, `compute_metrics.py` consumes a lot of memory and also takes very long to compute.
The reason for this is that for metric 5 computation, two list comprehensions are used to iterate over the genes in the genome. The output of the first list contains indices where a PAS was found. As this list is only used for computing how many PAS in a given gene are present, this does not need to be stored. 
The fix is to simply combine the two list comprehensions and only store the count of PAS per gene. This for sure decreases memory consumption and also should help in computation time.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [ ] In- and output formats comply with APAeval specifications
- [ ] No parameters or file names are hardcoded
- [ ] Results, logs or other output is not commited to the repository
- [ ] I have tested my code

