### PR TITLE
fix: deal with empty matched df

### DIFF
--- a/utils/apaeval/src/apaeval/main.py
+++ b/utils/apaeval/src/apaeval/main.py
@@ -130,12 +130,15 @@ def bedtools_window(bed1, bed2, window, reverse=False):
     
     # incase there were no sites returned (no overlap / all overlap in case of reverse=True)
     if not out.stdout.decode():
-        out = pd.DataFrame()
+        out = pd.DataFrame(columns=['chrom_p', 'chromStart_p', 'chromEnd_p', 'name_p', 
+            'score_p', 'strand_p', 'chrom_g', 'chromStart_g', 'chromEnd_g', 'name_g', 
+            'score_g', 'strand_g'])
     else:
         out = pd.read_csv(out_handle, delimiter='\t', header=None, dtype={0: str,6: str})
-        
-    # label columns
-    out.rename({0: 'chrom_p', 1: 'chromStart_p', 2: 'chromEnd_p', 3: 'name_p', 4: 'score_p', 5: 'strand_p', 6: 'chrom_g', 7: 'chromStart_g', 8: 'chromEnd_g', 9: 'name_g', 10: 'score_g', 11: 'strand_g'}, axis=1, inplace=True)
+        # label columns
+        out.rename({0: 'chrom_p', 1: 'chromStart_p', 2: 'chromEnd_p', 3: 'name_p', 4: 
+            'score_p', 5: 'strand_p', 6: 'chrom_g', 7: 'chromStart_g', 8: 'chromEnd_g', 9: 
+            'name_g', 10: 'score_g', 11: 'strand_g'}, axis=1, inplace=True)
    
     return(out)
 


### PR DESCRIPTION
The problem was that if the match within `bedtools_window` is empty, the dataframe was not correctly constructed and column names were not properly created. 
This caused a KeyError in `compute_metrics.py` when sorting the variable `matched`. 

The fix is to explicitly name the columns when creating the empty dataframe. 
The `else` statement is now extended to rename the columns from the non-empty (i.e. number of rows > 0) directly. 

I locally debugged the solution and it seems to work in that the variable `matched` is created with corresponding column names and the sorting successfully finishes. The metrics _sensitivity_ and _precision_ are evaluated to 0, as expected. 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code follows the templates/style guidelines of the repository
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

