### PR TITLE
fix: filter on score only after matched modifications

### DIFF
--- a/summary_workflows/quantification/quantification_dockers/q_metrics/compute_metrics.py
+++ b/summary_workflows/quantification/quantification_dockers/q_metrics/compute_metrics.py
@@ -80,9 +80,6 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant,
             ## Get matching sites
             matched = apa.bedtools_window(infile, gold_standard, window)
 
-            # filter TPM <= TPM_THRESHOLD
-            matched = matched.loc[matched.score_p > TPM_THRESHOLD,]
-
             # Number of duplicated PD sites, i.e. PD sites that matched multiple GT sites
             dPD_count = sum(matched.duplicated(PD_cols, keep="first")) 
 
@@ -99,6 +96,9 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant,
 
             # merge PD sites that matched with the same GT by summing their expression
             matched = apa.merge_pd_by_gt(matched)
+
+            # filter TPM <= TPM_THRESHOLD
+            matched = matched.loc[matched.score_p > TPM_THRESHOLD,]
 
             ## Get PD sites without matching GT (FP)
             only_PD = apa.bedtools_window(infile, gold_standard, window, reverse=True)


### PR DESCRIPTION
@ninsch3000 and I noticed when plotting scatter plots of correlation that the filtering by TPM threshold `-tpm` does not work as intended. 
The problem is that the function `split_pd_by_dist` can generate new prediction sites with score 0. The filtering was done prior to that though, so the matched dataframe ended up with 0 TPM scores even though the filter should remove them.

The fix is to move the filtering by TPM values to after modifying the matched object.

The function `merge_pd_by_gt` is not affected, since it would only merge and sum the expression from multiple prediction sites.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated corresponding READMEs (if applicable)
- [ ] My code follows the templates/style guidelines of the repository
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

