### PR TITLE
pyranges in utils/apaeval setup

### DIFF
--- a/utils/apaeval/setup.py
+++ b/utils/apaeval/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup, find_packages
 setup(
     packages=find_packages(where="src"),
     package_dir={'': 'src'},
-    install_requires=['scipy', 'pandas']
+    install_requires=['scipy', 'pandas', 'pyranges']
 )


### PR DESCRIPTION
Fixes "no module named pyranges" error when running q_metrics container

