### PR TITLE
fix: make SWF output jsons OEB compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 ### Code ###
 .vscode/*
 !.vscode/tasks.json
-!.vscode/launch.json
+.vscode/launch.json
 *.code-workspace
 
 ### Emacs ###
@@ -333,3 +333,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/python,vim,code,vscode,emacs,sublimetext,linux,macos,windows
+
+DATA/

--- a/summary_workflows/JSON_templates/src/JSON_templates/main.py
+++ b/summary_workflows/JSON_templates/src/JSON_templates/main.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import json
 import jsonschema
@@ -31,7 +31,7 @@ import sys
 """
 def write_participant_dataset( ID, community, challenges, participant_name, validated):
 
-    if validated == True:
+    if validated:
         status = "ok"
     else:
         status = "corrupted"
@@ -43,7 +43,7 @@ def write_participant_dataset( ID, community, challenges, participant_name, vali
         "type": "participant",
         "datalink": {
             "attrs": ["archive"],
-            "validation_date": str(datetime.now().replace(microsecond=0).isoformat()),
+            "validation_date": str(datetime.now(timezone.utc).replace(microsecond=0).isoformat()),
             "status": status
         },
         "participant_id": participant_name,

--- a/summary_workflows/identification/identification_dockers/build.sh
+++ b/summary_workflows/identification/identification_dockers/build.sh
@@ -11,7 +11,7 @@ if [ $# -gt 0 ]; then
 	tag_id="$1"
 
 	for docker_name in i_validation i_metrics i_consolidation ; do
-		docker build -t apaeval/"$docker_name":"$tag_id" "$docker_name"
+		docker build -t cjh4zavolab/"$docker_name":"$tag_id" "$docker_name"
 	done
 else
 	echo "Usage: $0 tag_id" 1>&2

--- a/summary_workflows/identification/identification_dockers/i_consolidation/aggregation.py
+++ b/summary_workflows/identification/identification_dockers/i_consolidation/aggregation.py
@@ -10,8 +10,9 @@ from OEB_aggr_query import OEB_aggr_query
 
 # set to production link when ready
 DEFAULT_OEB_API = "https://openebench.bsc.es/api/scientific/graphql"
-# Make sure to adapt accordingly in other event workflows; Here is APAeval:Identification
-DEFAULT_bench_event_id = "OEBE0070000001" # New benchmarking events (still empty): identification: "OEBE0070000001", quantification: "OEBE0070000002", differential usage: "OEBE0070000003"
+# Make sure to adapt accordingly in other event workflows; Here is APAeval:Identification_2021
+DEFAULT_bench_event_id = "OEBE0070000003" # New benchmarking events: Identification: "OEBE0070000003", absQuant: "OEBE0070000004"
+EVENT = "Identification_2021"
 
 class Visualisations(Enum):
     """Visualisations supported for plotting.
@@ -142,7 +143,7 @@ def main():
         # 2.c) If there's none, open the aggregation template instead        
         except FileNotFoundError:
             logging.warning(f"Couldn't find an existing aggregation file for challenge {challenge_id}. Creating a new file from {aggregation_template}!")
-            aggregation = load_aggregation_template(aggregation_template, community_id, event_date, challenge_id, metrics_ids)
+            aggregation = load_aggregation_template(aggregation_template, community_id, EVENT, event_date, challenge_id, metrics_ids)
                
         # if something else than the file missing went wrong
         except Exception:
@@ -276,7 +277,7 @@ def assert_object_type(json_obj, curr_type):
         raise TypeError(f"json object is of type {type_field}, should be {curr_type}")
 
 
-def load_aggregation_template(aggregation_template, community_id, event_date, challenge_id, metrics_ids):
+def load_aggregation_template(aggregation_template, community_id, EVENT, event_date, challenge_id, metrics_ids):
     '''
     Load the aggregation template from the provided json file and set _id and challenge_id; create objects for all window sizes
     '''
@@ -289,7 +290,7 @@ def load_aggregation_template(aggregation_template, community_id, event_date, ch
     # Create aggregation objects for all plots specified in the template, and for all metrics (different window sizes!) detected in the assessment. Fill objects with ID and challenge ID; data will be appended later
 
     # Prefix for aggregation object ids
-    base_id = f"{community_id}:{event_date}:{challenge_id}:Aggregation:"
+    base_id = f"{community_id}:{EVENT}:{challenge_id}:Aggregation:"
 
     # For all different plots
     for item in template:

--- a/summary_workflows/identification/identification_dockers/i_consolidation/aggregation.py
+++ b/summary_workflows/identification/identification_dockers/i_consolidation/aggregation.py
@@ -44,12 +44,6 @@ def parse_arguments():
         required=True
     )
     parser.add_argument(
-        "-d",
-        "--event_date",
-        help="passes in the event_date defined in nextflow.config",
-        required=True
-    )
-    parser.add_argument(
         "--offline",
         help="offline mode; if set to 1, existing benchmarking datasets will be read from local dir instead of OEB DB",
         default=0,
@@ -65,7 +59,6 @@ def main():
     benchmark_dir = options.benchmark_dir
     assessment_data = options.assessment_data
     output_dir = options.output
-    event_date = options.event_date
     offline = options.offline
 
     # Nextflow passes list, python reads list of strings. We need to clean up list elements
@@ -143,7 +136,7 @@ def main():
         # 2.c) If there's none, open the aggregation template instead        
         except FileNotFoundError:
             logging.warning(f"Couldn't find an existing aggregation file for challenge {challenge_id}. Creating a new file from {aggregation_template}!")
-            aggregation = load_aggregation_template(aggregation_template, community_id, EVENT, event_date, challenge_id, metrics_ids)
+            aggregation = load_aggregation_template(aggregation_template, community_id, EVENT, challenge_id, metrics_ids)
                
         # if something else than the file missing went wrong
         except Exception:
@@ -277,7 +270,7 @@ def assert_object_type(json_obj, curr_type):
         raise TypeError(f"json object is of type {type_field}, should be {curr_type}")
 
 
-def load_aggregation_template(aggregation_template, community_id, EVENT, event_date, challenge_id, metrics_ids):
+def load_aggregation_template(aggregation_template, community_id, EVENT, challenge_id, metrics_ids):
     '''
     Load the aggregation template from the provided json file and set _id and challenge_id; create objects for all window sizes
     '''

--- a/summary_workflows/identification/identification_dockers/i_consolidation/aggregation.py
+++ b/summary_workflows/identification/identification_dockers/i_consolidation/aggregation.py
@@ -2,7 +2,6 @@
 import os
 import json
 import logging
-import datetime
 from copy import deepcopy
 from enum import Enum
 from argparse import ArgumentParser, RawTextHelpFormatter
@@ -141,7 +140,7 @@ def main():
                 aggregation = json.load(f)
 
         # 2.c) If there's none, open the aggregation template instead        
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             logging.warning(f"Couldn't find an existing aggregation file for challenge {challenge_id}. Creating a new file from {aggregation_template}!")
             aggregation = load_aggregation_template(aggregation_template, community_id, event_date, challenge_id, metrics_ids)
                
@@ -186,9 +185,8 @@ def main():
         logging.debug(f"participants: {participants}")
 
         mani_obj = {
-            "id" : challenge_id_results,
+            "id" : challenge_id,
             "participants": participants,
-            'timestamp': datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
         }
 
         manifest.append(mani_obj)
@@ -259,7 +257,7 @@ def get_metrics_per_challenge(assessment_data):
 
         # make sure all objects belong to same participant
         if item["participant_id"] != participant_id:
-            raise ValueError(f"Something went wrong, not all metrics in the assessment file belong to the same participant.")
+            raise ValueError("Something went wrong, not all metrics in the assessment file belong to the same participant.")
     
     return community_id, participant_id, challenges
 

--- a/summary_workflows/identification/identification_dockers/i_consolidation/aggregation_template_I.json
+++ b/summary_workflows/identification/identification_dockers/i_consolidation/aggregation_template_I.json
@@ -27,7 +27,7 @@
                 "challenge_participants": [],
                 "visualization": {
                     "type": "bar-plot",
-                    "metric": "AUC"
+                    "metric": "Jaccard_index"
                 }
             }
         },

--- a/summary_workflows/identification/identification_dockers/i_consolidation/merge_data_model_files.py
+++ b/summary_workflows/identification/identification_dockers/i_consolidation/merge_data_model_files.py
@@ -28,22 +28,6 @@ def main(args):
     for v in validation_data:
         data_model_file = join_json_files(v, data_model_file, "*.json")
 
-    # Merge participant objects for the same participant, if validation was successful
-    # If validation failed, exit non-zero, as we can't deal with that here.
-    # First object:
-    if data_model_file[0]["datalink"]["status"] != "ok":
-        raise ValueError(f"Invalid participant object for {data_model_file[0]['participant_id']} on challenge {data_model_file[0]['challenge_id']}")
-
-    # Now merge remaining valid objects with the first one, if they are from the same tool
-    while len(data_model_file) > 1:
-        if data_model_file[1]["participant_id"] != data_model_file[0]["participant_id"]:
-            raise ValueError("Something went wrong, not all objects in the validation file belong to the same participant.")
-        if data_model_file[1]["datalink"]["status"] == "ok":
-            data_model_file[0]["challenge_id"].extend(data_model_file[1]["challenge_id"])
-        else:
-            raise ValueError(f"Invalid participant object for {data_model_file[0]['participant_id']} on challenge {data_model_file[0]['challenge_id']}")
-        data_model_file.pop(1)
-
     # 2. proceed with objects from Manifest...
     data_model_file = join_json_files(manifest_data, data_model_file, "*.json")
 

--- a/summary_workflows/identification/identification_dockers/i_metrics/compute_metrics.py
+++ b/summary_workflows/identification/identification_dockers/i_metrics/compute_metrics.py
@@ -7,7 +7,6 @@ import json
 import pandas as pd
 import numpy as np
 from argparse import ArgumentParser
-from sklearn.metrics import auc
 import JSON_templates
 import apaeval as apa
 
@@ -70,7 +69,7 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant, communi
         # Dict to store metric names and corresponding variables + stderr (which is currently not computed and set to 0)
         metrics = {}
 
-        # Vectors for AUC of precision recall curve
+        # Vectors for precision and recall
         p_vec = []
         r_vec = []
 
@@ -88,7 +87,7 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant, communi
         print(f"INFO: In challenge {challenge}. Using genome file: {genome_file}")
         genome = apa.load_genome(genome_file)
         
-        # For AUC of PR-curve we need more window sizes
+        # For PR-curve we need more window sizes
         windowlist = list(range(0,max(windows),max(windows)//10))
         # Just in case we're missing the specified windows now
         windowlist.extend([w for w in windows if w not in windowlist])
@@ -147,12 +146,6 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant, communi
                 metrics[f"Jaccard_index:{window}nt"] = [jaccard_index, 0]
                 metrics[f"multi_matched_PD:{window}nt"] = [dPD_proportion, 0]
                 metrics[f"multi_matched_GT:{window}nt"] = [dGT_proportion, 0]
-
-        # With precision and recall for all window sizes
-        pr_auc = auc(r_vec, p_vec)
-
-        # Save for assessment objects
-        metrics["AUC"] = [pr_auc, 0] 
 
         # METRICS:Percentage of genes with correctly identified number of PAS
         # count number of PAS per gene (i.e. row) in GT; stored as gene-ordered list.

--- a/summary_workflows/identification/identification_dockers/i_metrics/compute_metrics.py
+++ b/summary_workflows/identification/identification_dockers/i_metrics/compute_metrics.py
@@ -203,7 +203,7 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant, communi
         f.write(jdata)
 
     
-    with io.open(os.path.join(os.path.dirname(out_path), "rogue_metrics.json"), mode='w', encoding="utf-8") as f:
+    with io.open(os.path.join(os.path.dirname(out_path), "rogue_" + os.path.basename(out_path)), mode='w', encoding="utf-8") as f:
         jdata = json.dumps(rogue_assessments,                 
                     sort_keys=True,
                     indent=4,

--- a/summary_workflows/identification/identification_dockers/i_metrics/compute_metrics.py
+++ b/summary_workflows/identification/identification_dockers/i_metrics/compute_metrics.py
@@ -10,6 +10,9 @@ from argparse import ArgumentParser
 import JSON_templates
 import apaeval as apa
 
+# Make sure to adapt accordingly in other event workflows; Here is APAeval:Identification
+EVENT = "Identification_2021"
+
 def main(args):
 
     # input parameters
@@ -40,10 +43,10 @@ def main(args):
         except OSError as exc:
             print("OS error: {0}".format(exc) + "\nCould not create output path: " + out_path)
 
-    compute_metrics(participant_input, gold_standards_dir, challenges, participant, community, out_path, windows, genome_path)
+    compute_metrics(participant_input, gold_standards_dir, challenges, participant, community, EVENT, out_path, windows, genome_path)
 
 
-def compute_metrics(infile, gold_standards_dir, challenges, participant, community, out_path, windows, genome_path):
+def compute_metrics(infile, gold_standards_dir, challenges, participant, community, EVENT, out_path, windows, genome_path):
     
     # define array that will hold the full set of assessments
     all_assessments = []
@@ -64,7 +67,7 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant, communi
 
     for challenge in challenges:
         # ID prefix for assessment objects
-        base_id = f"{community}:{challenge}:{participant}:"
+        base_id = f"{community}:{EVENT}:{challenge}:{participant}:"
 
         # Dict to store metric names and corresponding variables + stderr (which is currently not computed and set to 0)
         metrics = {}

--- a/summary_workflows/identification/identification_dockers/i_metrics/constraints.txt
+++ b/summary_workflows/identification/identification_dockers/i_metrics/constraints.txt
@@ -10,3 +10,4 @@ pytz==2021.1
 six==1.16.0
 typing-extensions==3.10.0.0
 zipp==3.4.1
+pyranges==0.0.120

--- a/summary_workflows/identification/identification_dockers/i_metrics/constraints.txt
+++ b/summary_workflows/identification/identification_dockers/i_metrics/constraints.txt
@@ -10,4 +10,3 @@ pytz==2021.1
 six==1.16.0
 typing-extensions==3.10.0.0
 zipp==3.4.1
-scikit-learn==1.1.2

--- a/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
+++ b/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
@@ -4,4 +4,4 @@ scipy
 scikit-learn
 pyranges
 git+https://github.com/iRNA-COSI/APAeval.git@main#egg=apaeval&subdirectory=utils/apaeval
-git+https://github.com/iRNA-COSI/APAeval.git@main#egg=main&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
+++ b/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
@@ -4,4 +4,4 @@ scipy
 scikit-learn
 pyranges
 git+https://github.com/iRNA-COSI/APAeval.git@main#egg=apaeval&subdirectory=utils/apaeval
-git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
+++ b/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
@@ -1,7 +1,6 @@
 pandas
 jsonschema
 scipy
-scikit-learn
 pyranges
 git+https://github.com/iRNA-COSI/APAeval.git@main#egg=apaeval&subdirectory=utils/apaeval
 git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
+++ b/summary_workflows/identification/identification_dockers/i_metrics/requirements.txt
@@ -3,4 +3,4 @@ jsonschema
 scipy
 pyranges
 git+https://github.com/iRNA-COSI/APAeval.git@main#egg=apaeval&subdirectory=utils/apaeval
-git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/identification/identification_dockers/i_validation/requirements.txt
+++ b/summary_workflows/identification/identification_dockers/i_validation/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 jsonschema
-git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/identification/identification_dockers/i_validation/requirements.txt
+++ b/summary_workflows/identification/identification_dockers/i_validation/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 jsonschema
-git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/identification/identification_dockers/i_validation/validation.py
+++ b/summary_workflows/identification/identification_dockers/i_validation/validation.py
@@ -3,7 +3,8 @@
 from __future__ import division, print_function
 import pandas
 import numpy as np
-import os, json
+import os
+import json
 import sys
 from argparse import ArgumentParser
 import JSON_templates
@@ -71,7 +72,7 @@ def main(args):
     print(f"INFO: Selected challenge(s) {challenges}")
 
     for challenge in challenges:
-        # Get matching annotation file
+        # Check annotation files for all challenges
         gtf = select_genome_file(challenge, genome_path)
         print(f"INFO: Selected genome file {gtf}")
         chr_names = list()
@@ -87,12 +88,13 @@ def main(args):
         assert len(seqnames_wchr) == len(chr_names) or len(seqnames_wchr) == 0, \
             f"WARNING: {genome_path} has a mix of chromosome name formats!"
 
-    # Assuring the output path does exist
+    # Assuring the output path for validation.json does exist
     if not os.path.exists(os.path.dirname(out_path)):
         try:
             print(os.path.dirname(out_path))
             os.makedirs(os.path.dirname(out_path))
-            with open(out_path, mode="a") : pass
+            with open(out_path, mode="a") :
+                pass
         except OSError as exc:
             print("OS error: {0}".format(exc) + "\nCould not create output path: " + out_path)
 
@@ -149,7 +151,7 @@ def  validate_input_data(infile, community, challenges, participant_name, out_pa
         json.dump(output_json, f, sort_keys=True, indent=4, separators=(',', ': '))
 
     # Only pass if all input files are valid
-    if validated == True:
+    if validated:
         sys.exit(0)
     else:
         sys.exit("ERROR: One or more of the submitted files don't comply with APAeval specified format! Please check " + out_path)

--- a/summary_workflows/identification/identification_dockers/i_validation/validation.py
+++ b/summary_workflows/identification/identification_dockers/i_validation/validation.py
@@ -9,6 +9,11 @@ import sys
 from argparse import ArgumentParser
 import JSON_templates
 
+# Make sure to adapt accordingly in other event workflows!
+# Here is APAeval:Identification_2021
+DEFAULT_bench_event_id = "OEBE0070000003" 
+EVENT = "Identification_2021"
+
 parser = ArgumentParser()
 parser.add_argument("-i", "--participant_data", help="Execution workflow output file to be validated", required=True)
 parser.add_argument("-com", "--community_name", help="name of benchmarking community", required=True)
@@ -67,7 +72,8 @@ def main(args):
     print(f"INFO: input {participant_input}")
     print(f"INFO: Possible challenges {challenge_ids}")
 
-    challenges = [c for c in challenge_ids if c.split('.')[0] == str(participant_input).split('.')[1]]
+    sample_name = str(participant_input).split('.')[1]
+    challenges = [c for c in challenge_ids if c.split('.')[0] == sample_name]
     
     print(f"INFO: Selected challenge(s) {challenges}")
 
@@ -98,11 +104,10 @@ def main(args):
         except OSError as exc:
             print("OS error: {0}".format(exc) + "\nCould not create output path: " + out_path)
 
-    validate_input_data(participant_input, community, challenges, participant_name, out_path, chr_names)
+    validate_input_data(participant_input,sample_name, community, challenges, participant_name, out_path, chr_names)
 
 
-
-def  validate_input_data(infile, community, challenges, participant_name, out_path, chr_names):
+def validate_input_data(infile, sample_name, community, challenges, participant_name, out_path, chr_names):
 
     validated = False
 
@@ -143,7 +148,7 @@ def  validate_input_data(infile, community, challenges, participant_name, out_pa
     #----------------------------------------------------
 
 
-    data_id = community + ":" + participant_name
+    data_id = ":".join([community, EVENT, sample_name, participant_name])
     output_json = JSON_templates.write_participant_dataset(data_id, community, challenges, participant_name, validated)
 
     # print validated participant file

--- a/summary_workflows/identification/main.nf
+++ b/summary_workflows/identification/main.nf
@@ -119,8 +119,10 @@ process compute_metrics {
 	saveAs: { filename -> "assessments_${input_file.baseName}.json" }
 
 	publishDir out_dir,
-	pattern: "rogue_metrics.json",
-	saveAs: {filename -> "rogue/${input_file.baseName}/rogue_metrics.json"}
+	mode: 'copy',
+	overwrite: false,
+	pattern: "rogue_${input_file.baseName}.json",
+	saveAs: {filename -> "rogue_${input_file.baseName}.json"}
 
 	input:
 	val validation_status
@@ -134,7 +136,7 @@ process compute_metrics {
 
 	output:
 	path "${input_file.baseName}.json", emit: ass_json
-	path "rogue_metrics.json", emit: rogue_json
+	path "rogue_${input_file.baseName}.json", emit: rogue_json
 
 	when:
 	validation_status == 0

--- a/summary_workflows/identification/main.nf
+++ b/summary_workflows/identification/main.nf
@@ -65,7 +65,6 @@ gold_standards_dir = Channel.fromPath(params.goldstandard_dir, type: 'dir' )
 challenge_ids = params.challenges_ids
 benchmark_data = Channel.fromPath(params.aggregation_dir, type: 'dir' )
 community_id = params.community_id
-event_date = params.event_date
 windows = params.windows
 genome_dir = Channel.fromPath(params.genome_dir, type: 'dir' )
 offline = params.offline
@@ -167,7 +166,6 @@ process benchmark_consolidation {
 	val ass_json
 	val validation_file
 	val challenge_ids
-    val event_date
 	val offline
 	
 	output:
@@ -175,7 +173,7 @@ process benchmark_consolidation {
 	path "consolidated_result.json"
 
 	"""
-	python /app/aggregation.py -b $benchmark_data -a $ass_json -o results_dir -d $event_date --offline $offline
+	python /app/aggregation.py -b $benchmark_data -a $ass_json -o results_dir --offline $offline
 	python /app/merge_data_model_files.py -v $validation_file -m $ass_json -c $challenge_ids -a results_dir -o consolidated_result.json
 	"""
 
@@ -211,7 +209,6 @@ workflow {
 		assessments,
 		validations,
 		challenge_ids,
-		event_date,
 		offline
 		)
 }

--- a/summary_workflows/identification/nextflow.config
+++ b/summary_workflows/identification/nextflow.config
@@ -12,17 +12,17 @@ profiles {
    docker {
       process {
           withName: validation{
-            container = "docker.io/apaeval/i_validation:1.0"
+            container = "docker.io/cjh4zavolab/i_validation:1.0"
           }
       }
       process {
           withName: compute_metrics{
-            container = "docker.io/apaeval/i_metrics:1.0"
+            container = "docker.io/cjh4zavolab/i_metrics:1.0"
           }
       }
       process {
           withName: benchmark_consolidation{
-            container = "docker.io/apaeval/i_consolidation:1.0"
+            container = "docker.io/cjh4zavolab/i_consolidation:1.0"
           }
       }
       

--- a/summary_workflows/identification/nextflow.config
+++ b/summary_workflows/identification/nextflow.config
@@ -100,8 +100,6 @@ params  {
   genome_dir = "${params.data_dir}/ref/genomes" // Must contain a .gtf file with same substring as in challenge_ids, e.g. test.genome.mm10_test.gtf
   offline = 1 // type int; 0 for False
 
-  //set DEFAULT_eventMark
-  event_date = '2023-03-23'
 }
 
 // By default output execution reports

--- a/summary_workflows/identification/nextflow.config
+++ b/summary_workflows/identification/nextflow.config
@@ -80,7 +80,7 @@ params  {
 
   //name or OEB permanent ID for the benchmarking community
   community_id = "APAeval"
-  // name of APAeval benchmarking event (01: Identification, 02: absQuant, 03: diff, 04: relQuant)
+  // name of APAeval benchmarking event (Identification_01 or absQuant_02); only used for directory name, not passed to main.nf
   event = "Identification_01"
 
   // Boolean operator: if set to CLOSED the whole workflow is executed; if OPEN, metrics are computed but aggregation/consolidation is not performed

--- a/summary_workflows/identification/specification/I_benchmark_specification.md
+++ b/summary_workflows/identification/specification/I_benchmark_specification.md
@@ -27,10 +27,9 @@ Based on the input data the following metrics are computed:
 
 1. Sensitivity (TPR, True Positive Rate) = TP/(TP+FN)
 2. Precision = TP/(TP+FP)
-3. Area under the curve (AUC) of Precision-Recall curve calculated from Precision and Sensitivity (Recall) values for a range of distance thresholds
-4. Poly(A) sites matched to multiple ground truth sites as proportion of all identified sites
-5. Percentage of genes with correctly identified number of PAS
-6. Poly(A) sites assigned to different genomic features: terminal exons, exons (excluding terminal exons), introns, intergenic regions (less and more than 1kb downstream of 3'-terminal exon)
+3. Poly(A) sites matched to multiple ground truth sites as proportion of all identified sites
+4. Percentage of genes with correctly identified number of PAS
+5. Poly(A) sites assigned to different genomic features: terminal exons, exons (excluding terminal exons), introns, intergenic regions (less and more than 1kb downstream of 3'-terminal exon)
 
 TP - true positives - PAS identified by the tool and present in the orthogonal dataset  
 FP - false positives - PAS identified by the tool and not present in the orthogonal dataset  
@@ -102,13 +101,13 @@ Input datasets:
 - RNA-Seq data compared with 3'end sequencing data
 - Simulated RNA-Seq data compared with dataset used for simulation
 
-### 2. Bar plot visualizing AUC of Precision-Recall curve with single AUC value for each tool.
+### 2. Bar plot visualizing Jaccard index for each tool.
 
 **Plot type**: Bar plot
 
-**Metric**: AUC
+**Metric**: Jaccard index
 
-**Ranking**: The best performing tool is the one with the highest AUC value.
+**Ranking**: The best performing tool is the one with the highest Jaccard index.
 
 Input data:
 
@@ -140,7 +139,7 @@ This section includes plots that can be visualised outside of OpenEBench.
 **Metric Y**: Precision(d)  
 where _d - distance threshold_ in range 0-200 nt with 10 nt increments.
 
-**Ranking**: For each tool, the area under the curve is calculated. The best performing tool is the one with the highest AUC.
+**Ranking**: Best performance is top-right.
 
 Input datasets:
 
@@ -225,7 +224,6 @@ The following tables list the metric names, value types and units, and a descrip
 | `Sensitivity_10nt` | `float` | N/A | Sensitivity of PAS identification compared with orthogonal dataset; Sensitivity = (TP/(TP+FN)); calculated for 10 nt distance threshold |
 | `Sensitivity_50nt` | `float` | N/A | Sensitivity of PAS identification compared with orthogonal dataset; Sensitivity = (TP/(TP+FN)); calculated for 50 nt distance threshold |
 | `Sensitivity_100nt` | `float` | N/A | Sensitivity of PAS identification compared with orthogonal dataset; Sensitivity = (TP/(TP+FN)); calculated for 100 nt distance threshold |
-| `AUC` | `float` | N/A | Area under the curve (AUC) of Precision-Recall curve calculated from Precision and Recall (Sensitivity) values for a range of distance thresholds |
 | `Multi-matched_10nt` | `float` | % | Proportion of PAS identified from RNA-seq that were matched to multiple sites in grount truth; calculated for 10 nt distance threshold |
 | `Multi-matched_50nt` | `float` | % | Proportion of PAS identified from RNA-seq that were matched to multiple sites in grount truth; calculated for 50 nt distance threshold |
 | `Multi-matched_100nt` | `float` | % | Proportion of PAS identified from RNA-seq that were matched to multiple sites in grount truth; calculated for 100 nt distance threshold |

--- a/summary_workflows/identification/specification/example_files/aggregation_out.json
+++ b/summary_workflows/identification/specification/example_files/aggregation_out.json
@@ -1,6 +1,6 @@
 [
     {
-        "_id": "2022-04-27_datasetA_Aggregation_Precision_10nt_vs_Sensitivity_10nt",
+        "_id": "APAeval:2022-04-27:datasetA:Aggregation:Precision:10nt_vs_Sensitivity:10nt",
         "challenge_ids": [
             "datasetA"
         ],
@@ -20,15 +20,15 @@
                 ],
                 "visualization": {
                     "type": "2D-plot",
-                    "x_axis": "Sensitivity_10nt",
-                    "y_axis": "Precision_10nt"
+                    "x_axis": "Sensitivity:10nt",
+                    "y_axis": "Precision:10nt"
                 }
             }
         },
         "type": "aggregation"
     },
     {
-        "_id": "2022-04-27_datasetA_Aggregation_Precision_50nt_vs_Sensitivity_50nt",
+        "_id": "APAeval:2022-04-27:datasetA:Aggregation:Precision:50nt_vs_Sensitivity:50nt",
         "challenge_ids": [
             "datasetA"
         ],
@@ -48,15 +48,15 @@
                 ],
                 "visualization": {
                     "type": "2D-plot",
-                    "x_axis": "Sensitivity_50nt",
-                    "y_axis": "Precision_50nt"
+                    "x_axis": "Sensitivity:50nt",
+                    "y_axis": "Precision:50nt"
                 }
             }
         },
         "type": "aggregation"
     },
         {
-        "_id": "APAeval:2022-04-27_datasetA_Aggregation_Proportion_in_3UTR",
+        "_id": "APAeval:2022-04-27:datasetA:Aggregation:Jaccard_index:50nt",
         "challenge_ids": [
             "datasetA"
         ],
@@ -73,7 +73,7 @@
                     }
                 ],
                 "visualization": {
-                    "metric": "Proportion_in_3UTR",
+                    "metric": "Jaccard_index:50nt",
                     "type": "bar-plot"
                 }
             }

--- a/summary_workflows/identification/specification/example_files/assessment_out.json
+++ b/summary_workflows/identification/specification/example_files/assessment_out.json
@@ -1,10 +1,10 @@
 [
     {
-        "_id": "APAeval:datasetA_toolA_Precision_10nt",
+        "_id": "APAeval:datasetA:toolA:Precision:10nt",
         "challenge_id": "datasetA",
         "community_id": "APAeval",
         "metrics": {
-            "metric_id": "Precision_10nt",
+            "metric_id": "Precision:10nt",
             "stderr": 0,
             "value": 0.54
         },
@@ -12,11 +12,11 @@
         "type": "assessment"
     },
     {
-        "_id": "APAeval:datasetA_toolA_Precision_50nt",
+        "_id": "APAeval:datasetA:toolA:Precision:50nt",
         "challenge_id": "datasetA",
         "community_id": "APAeval",
         "metrics": {
-            "metric_id": "Precision_50nt",
+            "metric_id": "Precision:50nt",
             "stderr": 0,
             "value": 0.85
         },
@@ -24,11 +24,11 @@
         "type": "assessment"
     },
     {
-        "_id": "APAeval:datasetA_toolA_Sensitivity_10nt",
+        "_id": "APAeval:datasetA:toolA:Sensitivity:10nt",
         "challenge_id": "datasetA",
         "community_id": "APAeval",
         "metrics": {
-            "metric_id": "Sensitivity_10nt",
+            "metric_id": "Sensitivity:10nt",
             "stderr": 0,
             "value": 0.76
         },
@@ -36,11 +36,11 @@
         "type": "assessment"
     },
     {
-        "_id": "APAeval:datasetA_toolA_Sensitivity_50nt",
-        "challenge_id": "datasetB",
+        "_id": "APAeval:datasetA:toolA:Sensitivity:50nt",
+        "challenge_id": "datasetA",
         "community_id": "APAeval",
         "metrics": {
-            "metric_id": "Sensitivity_50nt",
+            "metric_id": "Sensitivity:50nt",
             "stderr": 0,
             "value": 0.81
         },

--- a/summary_workflows/quantification/main.nf
+++ b/summary_workflows/quantification/main.nf
@@ -71,7 +71,6 @@ gold_standards_dir = Channel.fromPath(params.goldstandard_dir, type: 'dir' )
 challenge_ids = params.challenges_ids
 benchmark_data = Channel.fromPath(params.aggregation_dir, type: 'dir' )
 community_id = params.community_id
-event_date = params.event_date
 windows = params.windows
 genome_dir = Channel.fromPath(params.genome_dir, type: 'dir' )
 tpm_threshold = params.tpm_threshold
@@ -168,7 +167,6 @@ process benchmark_consolidation {
 	val ass_json
 	val validation_file
 	val challenge_ids
-    val event_date
 	val offline
 	
 	output:
@@ -176,7 +174,7 @@ process benchmark_consolidation {
 	path "consolidated_result.json"
 
 	"""
-	python /app/aggregation.py -b $benchmark_data -a $ass_json -o results_dir -d $event_date --offline $offline
+	python /app/aggregation.py -b $benchmark_data -a $ass_json -o results_dir --offline $offline
 	python /app/merge_data_model_files.py -v $validation_file -m $ass_json -c $challenge_ids -a results_dir -o consolidated_result.json
 	"""
 
@@ -213,7 +211,6 @@ workflow {
 		assessments,
 		validations,
 		challenge_ids,
-		event_date,
 		offline
 		)
 }

--- a/summary_workflows/quantification/nextflow.config
+++ b/summary_workflows/quantification/nextflow.config
@@ -80,7 +80,7 @@ params  {
 
   //name or OEB permanent ID for the benchmarking community
   community_id = "APAeval"
-  // name of APAeval benchmarking event (01: Identification, 02: absQuant, 03: diff, 04: relQuant)
+  // name of APAeval benchmarking event (Identification_01 or absQuant_02); only used for directory name, not passed to main.nf
   event = "AbsQuant_02"
 
   // Boolean operator: if set to CLOSED the whole workflow is executed; if OPEN, metrics are computed but aggregation/consolidation is not performed
@@ -103,8 +103,6 @@ params  {
   tpm_threshold = 0 // Expression filter for predictions. PolyA sites with smaller or equal transcripts per million (tpm) will be removed before metric compuatation.
   offline = 1 // type int; 0 for False
 
-  //set DEFAULT_eventMark
-  event_date = '2023-03-23'
 }
 
 // By default output execution reports

--- a/summary_workflows/quantification/nextflow.config
+++ b/summary_workflows/quantification/nextflow.config
@@ -12,17 +12,17 @@ profiles {
   docker {
       process {
           withName: validation{
-            container = "docker.io/apaeval/q_validation:1.0"
+            container = "docker.io/cjh4zavolab/q_validation:1.0"
           }
       }
       process {
           withName: compute_metrics{
-            container = "docker.io/apaeval/q_metrics:1.0"
+            container = "docker.io/cjh4zavolab/q_metrics:1.0"
           }
       }
       process {
           withName: benchmark_consolidation{
-            container = "docker.io/apaeval/q_consolidation:1.0"
+            container = "docker.io/cjh4zavolab/q_consolidation:1.0"
           }
       }
       
@@ -97,7 +97,9 @@ params  {
 
   // other parameters
   windows = "100 50 10" // type int, several values inside string separated by spaces. The first value is used for relative PAS usage calculation.
-  genome_dir = "${params.data_dir}/ref/genomes" // Must contain a .gtf file with same substring as in challenge_ids, e.g. test.genome.mm10_test.gtf
+
+  genome_dir = "${params.goldstandard_dir}/genomes" // Must contain a .gtf file with same substring as in challenge_ids, e.g. test.genome.mm10_test.gtf
+
   tpm_threshold = 0 // Expression filter for predictions. PolyA sites with smaller or equal transcripts per million (tpm) will be removed before metric compuatation.
   offline = 1 // type int; 0 for False
 

--- a/summary_workflows/quantification/quantification_dockers/build.sh
+++ b/summary_workflows/quantification/quantification_dockers/build.sh
@@ -11,7 +11,7 @@ if [ $# -gt 0 ]; then
 	tag_id="$1"
 
 	for docker_name in q_validation q_metrics q_consolidation ; do
-		docker build -t apaeval/"$docker_name":"$tag_id" "$docker_name"
+		docker build -t cjh4zavolab/"$docker_name":"$tag_id" "$docker_name"
 	done
 else
 	echo "Usage: $0 tag_id" 1>&2

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
@@ -44,12 +44,6 @@ def parse_arguments():
         required=True
     )
     parser.add_argument(
-        "-d",
-        "--event_date",
-        help="passes in the event_date defined in nextflow.config",
-        required=True
-    )
-    parser.add_argument(
         "--offline",
         help="offline mode; if set to 1, existing benchmarking datasets will be read from local dir instead of OEB DB",
         default=0,
@@ -65,7 +59,6 @@ def main():
     benchmark_dir = options.benchmark_dir
     assessment_data = options.assessment_data
     output_dir = options.output
-    event_date = options.event_date
     offline = options.offline
 
     # Nextflow passes list, python reads list of strings. We need to clean up list elements
@@ -143,7 +136,7 @@ def main():
         # 2.c) If there's none, open the aggregation template instead        
         except FileNotFoundError:
             logging.warning(f"Couldn't find an existing aggregation file for challenge {challenge_id}. Creating a new file from {aggregation_template}!")
-            aggregation = load_aggregation_template(aggregation_template, community_id, EVENT, event_date, challenge_id, metrics_ids)
+            aggregation = load_aggregation_template(aggregation_template, community_id, EVENT, challenge_id, metrics_ids)
                
         # if something else than the file missing went wrong
         except Exception:
@@ -277,7 +270,7 @@ def assert_object_type(json_obj, curr_type):
         raise TypeError(f"json object is of type {type_field}, should be {curr_type}")
 
 
-def load_aggregation_template(aggregation_template, community_id, EVENT, event_date, challenge_id, metrics_ids):
+def load_aggregation_template(aggregation_template, community_id, EVENT, challenge_id, metrics_ids):
     '''
     Load the aggregation template from the provided json file and set _id and challenge_id; create objects for all window sizes
     '''

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
@@ -10,8 +10,9 @@ from OEB_aggr_query import OEB_aggr_query
 
 # set to production link when ready
 DEFAULT_OEB_API = "https://openebench.bsc.es/api/scientific/graphql"
-# Make sure to adapt accordingly in other event workflows; Here is APAeval:Quantification
-DEFAULT_bench_event_id = "OEBE0070000002" # New benchmarking events (still empty): identification: "OEBE0070000001", quantification: "OEBE0070000002", differential usage: "OEBE0070000003"
+# Make sure to adapt accordingly in other event workflows; Here is APAeval:absQuant_2021
+DEFAULT_bench_event_id = "OEBE0070000004" # New benchmarking events: Identification: "OEBE0070000003", absQuant: "OEBE0070000004"
+EVENT = "absQuant_2021"
 
 class Visualisations(Enum):
     """Visualisations supported for plotting.
@@ -142,7 +143,7 @@ def main():
         # 2.c) If there's none, open the aggregation template instead        
         except FileNotFoundError:
             logging.warning(f"Couldn't find an existing aggregation file for challenge {challenge_id}. Creating a new file from {aggregation_template}!")
-            aggregation = load_aggregation_template(aggregation_template, community_id, event_date, challenge_id, metrics_ids)
+            aggregation = load_aggregation_template(aggregation_template, community_id, EVENT, event_date, challenge_id, metrics_ids)
                
         # if something else than the file missing went wrong
         except Exception:
@@ -276,7 +277,7 @@ def assert_object_type(json_obj, curr_type):
         raise TypeError(f"json object is of type {type_field}, should be {curr_type}")
 
 
-def load_aggregation_template(aggregation_template, community_id, event_date, challenge_id, metrics_ids):
+def load_aggregation_template(aggregation_template, community_id, EVENT, event_date, challenge_id, metrics_ids):
     '''
     Load the aggregation template from the provided json file and set _id and challenge_id; create objects for all window sizes
     '''
@@ -289,7 +290,7 @@ def load_aggregation_template(aggregation_template, community_id, event_date, ch
     # Create aggregation objects for all plots specified in the template, and for all metrics (different window sizes!) detected in the assessment. Fill objects with ID and challenge ID; data will be appended later
 
     # Prefix for aggregation object ids
-    base_id = f"{community_id}:{event_date}:{challenge_id}:Aggregation:"
+    base_id = f"{community_id}:{EVENT}:{challenge_id}:Aggregation:"
 
     # For all different plots
     for item in template:

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation.py
@@ -2,7 +2,6 @@
 import os
 import json
 import logging
-import datetime
 from copy import deepcopy
 from enum import Enum
 from argparse import ArgumentParser, RawTextHelpFormatter
@@ -141,7 +140,7 @@ def main():
                 aggregation = json.load(f)
 
         # 2.c) If there's none, open the aggregation template instead        
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             logging.warning(f"Couldn't find an existing aggregation file for challenge {challenge_id}. Creating a new file from {aggregation_template}!")
             aggregation = load_aggregation_template(aggregation_template, community_id, event_date, challenge_id, metrics_ids)
                
@@ -186,9 +185,8 @@ def main():
         logging.debug(f"participants: {participants}")
 
         mani_obj = {
-            "id" : challenge_id_results,
+            "id" : challenge_id,
             "participants": participants,
-            'timestamp': datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
         }
 
         manifest.append(mani_obj)
@@ -259,7 +257,7 @@ def get_metrics_per_challenge(assessment_data):
 
         # make sure all objects belong to same participant
         if item["participant_id"] != participant_id:
-            raise ValueError(f"Something went wrong, not all metrics in the assessment file belong to the same participant.")
+            raise ValueError("Something went wrong, not all metrics in the assessment file belong to the same participant.")
     
     return community_id, participant_id, challenges
 

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation_template_Q.json
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/aggregation_template_Q.json
@@ -9,8 +9,8 @@
                 "challenge_participants": [],
                 "visualization": {
                     "type": "2D-plot",
-                    "x_axis": "Sum_FP_TPM",
-                    "y_axis": "Pearson_r:all_GT",
+                    "x_axis": "Percent_FP_TPM",
+                    "y_axis": "Pearson_r:intersection",
                     "optimization": "top-left"
                 }
             }
@@ -27,7 +27,7 @@
                 "challenge_participants": [],
                 "visualization": {
                     "type": "bar-plot",
-                    "metric": "Pearson_r_relative:union"
+                    "metric": "F1_score"
                 }
             }
         },

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/merge_data_model_files.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/merge_data_model_files.py
@@ -28,22 +28,6 @@ def main(args):
     for v in validation_data:
         data_model_file = join_json_files(v, data_model_file, "*.json")
 
-    # Merge participant objects for the same participant, if validation was successful
-    # If validation failed, exit non-zero, as we can't deal with that here.
-    # First object:
-    if data_model_file[0]["datalink"]["status"] != "ok":
-        raise ValueError(f"Invalid participant object for {data_model_file[0]['participant_id']} on challenge {data_model_file[0]['challenge_id']}")
-
-    # Now merge remaining valid objects with the first one, if they are from the same tool
-    while len(data_model_file) > 1:
-        if data_model_file[1]["participant_id"] != data_model_file[0]["participant_id"]:
-            raise ValueError("Something went wrong, not all objects in the validation file belong to the same participant.")
-        if data_model_file[1]["datalink"]["status"] == "ok":
-            data_model_file[0]["challenge_id"].extend(data_model_file[1]["challenge_id"])
-        else:
-            raise ValueError(f"Invalid participant object for {data_model_file[0]['participant_id']} on challenge {data_model_file[0]['challenge_id']}")
-        data_model_file.pop(1)
-
     # 2. proceed with objects from Manifest...
     data_model_file = join_json_files(manifest_data, data_model_file, "*.json")
 

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/merge_data_model_files.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/merge_data_model_files.py
@@ -12,13 +12,14 @@ def main(args):
     metrics_data = args.metrics_data
     validation_data = args.validation_data
     aggregation_data = args.aggregation_data
+    manifest_data = os.path.join(aggregation_data, "Manifest.json")
     challenges = args.challenge_ids
     out_path = args.output
-    print(out_path)
 
     # Nextflow passes list, python reads string. We need python lists
     metrics_data = [m.strip('[').strip(']').strip(',') for m in metrics_data]
     validation_data = [v.strip('[').strip(']').strip(',') for v in validation_data]
+
             
     # This is the final consolidated output
     data_model_file = []
@@ -27,6 +28,8 @@ def main(args):
     # from validation ("validated_participant_data")
     for v in validation_data:
         data_model_file = join_json_files(v, data_model_file, "*.json")
+    # from Manifest
+    data_model_file = join_json_files(manifest_data, data_model_file, "*.json")
     # from metrics ("assessment_out")
     for m in metrics_data:
         data_model_file = join_json_files(m, data_model_file, "*.json")

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/merge_data_model_files.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/merge_data_model_files.py
@@ -28,11 +28,22 @@ def main(args):
     # from validation ("validated_participant_data")
     for v in validation_data:
         data_model_file = join_json_files(v, data_model_file, "*.json")
-    # from Manifest
+
+    # Merge participant objects for the same participant, if validation was successful
+    first_o = data_model_file[0]
+    for o in range(1,len(data_model_file)):
+        if (data_model_file[o]["participant_id"] == first_o["participant_id"] and data_model_file[o]["datalink"]["status"] == "ok"):
+            first_o["challenge_id"].extend(data_model_file[o]["challenge_id"])
+            del data_model_file[o]
+
+
+    # proceed with objects from Manifest...
     data_model_file = join_json_files(manifest_data, data_model_file, "*.json")
-    # from metrics ("assessment_out")
+
+    # ...and from metrics ("assessment_out")
     for m in metrics_data:
         data_model_file = join_json_files(m, data_model_file, "*.json")
+
     # from consolidation part 1 (manage_assessment_data.py), "sample_out/results/challenge/challenge.json"
     # we have to do that for all challenges in the list
     for challenge in challenges:

--- a/summary_workflows/quantification/quantification_dockers/q_consolidation/merge_data_model_files.py
+++ b/summary_workflows/quantification/quantification_dockers/q_consolidation/merge_data_model_files.py
@@ -20,31 +20,38 @@ def main(args):
     metrics_data = [m.strip('[').strip(']').strip(',') for m in metrics_data]
     validation_data = [v.strip('[').strip(']').strip(',') for v in validation_data]
 
-            
     # This is the final consolidated output
     data_model_file = []
 
     # get the output files from previous steps and concatenate
-    # from validation ("validated_participant_data")
+    # 1. from validation ("validated_participant_data")
     for v in validation_data:
         data_model_file = join_json_files(v, data_model_file, "*.json")
 
     # Merge participant objects for the same participant, if validation was successful
-    first_o = data_model_file[0]
-    for o in range(1,len(data_model_file)):
-        if (data_model_file[o]["participant_id"] == first_o["participant_id"] and data_model_file[o]["datalink"]["status"] == "ok"):
-            first_o["challenge_id"].extend(data_model_file[o]["challenge_id"])
-            del data_model_file[o]
+    # If validation failed, exit non-zero, as we can't deal with that here.
+    # First object:
+    if data_model_file[0]["datalink"]["status"] != "ok":
+        raise ValueError(f"Invalid participant object for {data_model_file[0]['participant_id']} on challenge {data_model_file[0]['challenge_id']}")
 
+    # Now merge remaining valid objects with the first one, if they are from the same tool
+    while len(data_model_file) > 1:
+        if data_model_file[1]["participant_id"] != data_model_file[0]["participant_id"]:
+            raise ValueError("Something went wrong, not all objects in the validation file belong to the same participant.")
+        if data_model_file[1]["datalink"]["status"] == "ok":
+            data_model_file[0]["challenge_id"].extend(data_model_file[1]["challenge_id"])
+        else:
+            raise ValueError(f"Invalid participant object for {data_model_file[0]['participant_id']} on challenge {data_model_file[0]['challenge_id']}")
+        data_model_file.pop(1)
 
-    # proceed with objects from Manifest...
+    # 2. proceed with objects from Manifest...
     data_model_file = join_json_files(manifest_data, data_model_file, "*.json")
 
-    # ...and from metrics ("assessment_out")
+    # ...and 3. from metrics ("assessment_out")
     for m in metrics_data:
         data_model_file = join_json_files(m, data_model_file, "*.json")
 
-    # from consolidation part 1 (manage_assessment_data.py), "sample_out/results/challenge/challenge.json"
+    # 4. from consolidation part 1 (manage_assessment_data.py), "sample_out/results/challenge/challenge.json"
     # we have to do that for all challenges in the list
     for challenge in challenges:
         challenge = challenge.replace('.', '_')

--- a/summary_workflows/quantification/quantification_dockers/q_metrics/compute_metrics.py
+++ b/summary_workflows/quantification/quantification_dockers/q_metrics/compute_metrics.py
@@ -9,6 +9,9 @@ from argparse import ArgumentParser
 import JSON_templates
 import apaeval as apa
 
+# Make sure to adapt accordingly in other event workflows; Here is APAeval:absQuant
+EVENT = "absQuant_2021"
+
 def main(args):
 
     # input parameters
@@ -39,11 +42,11 @@ def main(args):
         except OSError as exc:
             print("OS error: {0}".format(exc) + "\nCould not create output path: " + out_path)
 
-    compute_metrics(participant_input, gold_standards_dir, challenges, participant, community, out_path, windows, genome_path, tpm_threshold)
+    compute_metrics(participant_input, gold_standards_dir, challenges, participant, community, EVENT, out_path, windows, genome_path, tpm_threshold)
 
 
 def compute_metrics(infile, gold_standards_dir, challenges, participant,
-    community, out_path, windows, genome_path, TPM_THRESHOLD):
+    community, EVENT, out_path, windows, genome_path, TPM_THRESHOLD):
 
     # define array that will hold the full set of assessment datasets
     all_assessments = []
@@ -51,7 +54,7 @@ def compute_metrics(infile, gold_standards_dir, challenges, participant,
     all_return_df_types = ["all_GT", "union", "intersection"]
     for challenge in challenges:
         # ID prefix for assessment objects
-        base_id = f"{community}:{challenge}:{participant}:"
+        base_id = f"{community}:{EVENT}:{challenge}:{participant}:"
         # Dict to store metric names and corresponding variables + stderr (which is currently not computed and set to 0)
         metrics = {}
 

--- a/summary_workflows/quantification/quantification_dockers/q_metrics/requirements.txt
+++ b/summary_workflows/quantification/quantification_dockers/q_metrics/requirements.txt
@@ -2,4 +2,4 @@ pandas
 jsonschema
 scipy
 git+https://github.com/iRNA-COSI/APAeval.git@main#egg=apaeval&subdirectory=utils/apaeval
-git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/quantification/quantification_dockers/q_metrics/requirements.txt
+++ b/summary_workflows/quantification/quantification_dockers/q_metrics/requirements.txt
@@ -2,4 +2,4 @@ pandas
 jsonschema
 scipy
 git+https://github.com/iRNA-COSI/APAeval.git@main#egg=apaeval&subdirectory=utils/apaeval
-git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/quantification/quantification_dockers/q_validation/requirements.txt
+++ b/summary_workflows/quantification/quantification_dockers/q_validation/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 jsonschema
-git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/quantification/quantification_dockers/q_validation/requirements.txt
+++ b/summary_workflows/quantification/quantification_dockers/q_validation/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 jsonschema
-git+https://github.com/iRNA-COSI/APAeval.git@main#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates
+git+https://github.com/iRNA-COSI/APAeval.git@oeb_jsons#egg=JSON_templates&subdirectory=summary_workflows/JSON_templates

--- a/summary_workflows/quantification/quantification_dockers/q_validation/validation.py
+++ b/summary_workflows/quantification/quantification_dockers/q_validation/validation.py
@@ -9,6 +9,11 @@ import sys
 from argparse import ArgumentParser
 import JSON_templates
 
+# Make sure to adapt accordingly in other event workflows!
+# Here is APAeval:absQuant_2021
+DEFAULT_bench_event_id = "OEBE0070000004" 
+EVENT = "absQuant_2021"
+
 parser = ArgumentParser()
 parser.add_argument("-i", "--participant_data", help="Execution workflow output file to be validated", required=True)
 parser.add_argument("-com", "--community_name", help="name of benchmarking community", required=True)
@@ -67,7 +72,8 @@ def main(args):
     print(f"INFO: input {participant_input}")
     print(f"INFO: Possible challenges {challenge_ids}")
 
-    challenges = [c for c in challenge_ids if c.split('.')[0] == str(participant_input).split('.')[1]]
+    sample_name = str(participant_input).split('.')[1]
+    challenges = [c for c in challenge_ids if c.split('.')[0] == sample_name]
     
     print(f"INFO: Selected challenge(s) {challenges}")
 
@@ -98,11 +104,11 @@ def main(args):
         except OSError as exc:
             print("OS error: {0}".format(exc) + "\nCould not create output path: " + out_path)
 
-    validate_input_data(participant_input, community, challenges, participant_name, out_path, chr_names)
+    validate_input_data(participant_input, sample_name, community, challenges, participant_name, out_path, chr_names)
 
 
 
-def  validate_input_data(infile, community, challenges, participant_name, out_path, chr_names):
+def  validate_input_data(infile, sample_name, community, challenges, participant_name, out_path, chr_names):
 
     validated = False
 
@@ -143,7 +149,7 @@ def  validate_input_data(infile, community, challenges, participant_name, out_pa
     #----------------------------------------------------
 
 
-    data_id = community + ":" + participant_name
+    data_id = ":".join([community, EVENT, sample_name, participant_name])
     output_json = JSON_templates.write_participant_dataset(data_id, community, challenges, participant_name, validated)
 
     # print validated participant file

--- a/summary_workflows/quantification/quantification_dockers/q_validation/validation.py
+++ b/summary_workflows/quantification/quantification_dockers/q_validation/validation.py
@@ -3,7 +3,8 @@
 from __future__ import division, print_function
 import pandas
 import numpy as np
-import os, json
+import os
+import json
 import sys
 from argparse import ArgumentParser
 import JSON_templates
@@ -92,7 +93,8 @@ def main(args):
         try:
             print(os.path.dirname(out_path))
             os.makedirs(os.path.dirname(out_path))
-            with open(out_path, mode="a") : pass
+            with open(out_path, mode="a") :
+                pass
         except OSError as exc:
             print("OS error: {0}".format(exc) + "\nCould not create output path: " + out_path)
 
@@ -149,7 +151,7 @@ def  validate_input_data(infile, community, challenges, participant_name, out_pa
         json.dump(output_json, f, sort_keys=True, indent=4, separators=(',', ': '))
 
     # Only pass if all input files are valid
-    if validated == True:
+    if validated:
         sys.exit(0)
     else:
         sys.exit("ERROR: One or more of the submitted files don't comply with APAeval specified format! Please check " + out_path)

--- a/summary_workflows/quantification/quantification_dockers/q_validation/validation.py
+++ b/summary_workflows/quantification/quantification_dockers/q_validation/validation.py
@@ -67,7 +67,7 @@ def main(args):
     print(f"INFO: input {participant_input}")
     print(f"INFO: Possible challenges {challenge_ids}")
 
-    challenges = [c for c in challenge_ids if c.split('.')[0] ==  str(participant_input).split('.')[1]]
+    challenges = [c for c in challenge_ids if c.split('.')[0] == str(participant_input).split('.')[1]]
     
     print(f"INFO: Selected challenge(s) {challenges}")
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -7,6 +7,7 @@ Contents:
   - [Convert GTF to BED12 (aka 'gene model') file](#convert-gtf-to-bed12-aka-gene-model-file)
   - [Convert .csv to .tsv (NO Docker)](#convert-csv-to-tsv-no-docker)
   - [Convert assessment json to .tsv (NO Docker)](#convert-assessment-json-to-tsv-no-docker)
+  - [Filter assessment json (NO Docker)](#filter-assessment-json-no-docker)
 - [Contributing instructions](#contributing-instructions)
 
 
@@ -55,6 +56,20 @@ Currently no Docker image available, but the script can be run inside the `apaev
 **Usage:**
 ```
 python metrics_json2tsv.py --file-list assessment1.json assessment2.json --output metrics.tsv
+```
+
+### Filter assessment json (NO Docker)
+
+**Description:** Filter a summary workflow output json file, i.e. remove objects that belong to specified metrics or challenges. Parts of metric- or challenge names can be specified and all objects (participant, assessment, aggregation, manifest-like) containing those metrics or challenges are removed.
+
+**Subdirectory name**: `filter_jsons`
+
+**Compatibility:**
+Currently no Docker image available, but the script can be run inside the `apaeval_execution_workflow` conda environment. 
+
+**Usage:**
+```
+python filter_jsons.py --file-list assessment1.json assessment2.json --out_prefix "filtered_" --b_metrics "union all_GT Spearman relative 25nt multi_matched FDR" --b_challenges "TE"
 ```
 ## Contributing instructions
 

--- a/utils/apaeval/main.md
+++ b/utils/apaeval/main.md
@@ -62,16 +62,21 @@ Functions
 :   Returns Jaccard index of prediction.
 
     
-`load_genome(genome_path)`
+`load_genome(genome_path, feature='gene')`
 :   Load genome annotation in gtf format.
     
-    Requires feature 'gene', which is available in gencode.
+    And subset to only return feature.
+    E.g. feature 'gene', which is available in gencode.
+    
+    Note:
+        The returned dataframe contains all attributes as read in by pyranges.
     
     Args:
         genome_path: file path for gtf.
+        feature (str): feature to subset. Default: gene.
     
     Returns:
-        pandas.df with genes.
+        pandas.df with [feature] rows from genome.
 
     
 `merge_pd_by_gt(matched_sites)`

--- a/utils/filter_jsons/filter_jsons.py
+++ b/utils/filter_jsons/filter_jsons.py
@@ -1,0 +1,123 @@
+from argparse import ArgumentParser, RawTextHelpFormatter
+import json
+import logging
+
+logging.basicConfig(
+            level=logging.DEBUG, 
+            format='%(asctime)s %(levelname)s:%(message)s', datefmt='%Y-%m-%d %H:%M:%S ')
+LOGGER = logging.getLogger(__name__)
+
+def parse_arguments():
+    '''
+    Parser of command-line arguments.
+    '''
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+    parser.add_argument(
+        "-f", 
+        "--file-list", 
+        help="list of OEB .json (assessments, validation or consolidation) filepaths.", required=True, nargs="+"
+    )
+    parser.add_argument(
+        "-o",
+        "--out_prefix",
+        help="prefix for output files",
+        required=True
+    )
+    parser.add_argument(
+        "-m",
+        "--b_metrics",
+        help="list of metrics to be removed",
+        nargs='?',
+        default = ""
+    )
+    parser.add_argument(
+        "-c",
+        "--b_challenges",
+        help="list of challenges to be removed",
+        nargs='?',
+        default= ""
+    )
+    return parser
+
+
+def main():
+    # input parameters
+    file_list = options.file_list
+    out_prefix = options.out_prefix
+    bad_metrics = options.b_metrics.strip().split(" ")
+    bad_challenges = options.b_challenges.strip().split(" ")
+
+    LOGGER.info(f"badlisted metric elements: {bad_metrics}")
+    LOGGER.info(f"badlisted challenge elements: {bad_challenges}")
+
+    # for each json file in input list
+    for f in file_list:
+        LOGGER.debug(f"Filename: {f}")
+        new_jobjects = []
+        with open(f, mode='r', encoding="utf-8") as infile:
+            try:
+                jobjects = json.load(infile)
+            except Exception as exc:
+                LOGGER.error(f"Can't read json file, please check format.")
+                raise exc
+
+        # for each object in json file
+        for j in jobjects:
+            LOGGER.debug(f"Object: {j}")
+            # object is from the manifest
+            if not 'type' in j:
+                bad_c = []
+                if bad_challenges[0]:
+                    bad_c = [True for c in bad_challenges if c in j['id']]
+                if not any(bad_c):
+                    new_jobjects.append(j)
+
+            # object is participant object
+            elif j['type'] == 'participant':
+                # From a list of challenges only keep those that don't contain a bad element
+                challenges = []
+                bad_c = []
+                for c in j['challenge_id']:
+                    if bad_challenges[0]:
+                        bad_c = [True for b in bad_challenges if b in c]
+                    if not any(bad_c):
+                        challenges.append(c)
+                j['challenge_id'] = challenges
+                new_jobjects.append(j)
+
+            # object is assessment or aggregation object
+            elif (j['type'] == 'assessment') or (j['type'] == 'aggregation'):
+                # Check for bad metric elements
+                bad_m = []
+                if bad_metrics[0]:
+                    bad_m = [True for b in bad_metrics if b in j['_id']]
+                # Check for bad challenge elements
+                bad_c = []
+                if bad_challenges[0]:
+                    bad_c = [True for c in bad_challenges if c in j['_id']]
+                # Decide whether to keep object
+                if (not any(bad_m)) and (not any(bad_c)):
+                    new_jobjects.append(j)
+
+            
+        # And write to file
+        with open(out_prefix + f, mode='w', encoding='utf-8') as outfile:
+            jdata = json.dumps(new_jobjects, sort_keys=True, indent=4, separators=(',', ': '))
+            outfile.write(jdata)
+
+    return
+
+
+
+
+
+if __name__ == '__main__':
+    # parse the command-line arguments
+    options = parse_arguments().parse_args()
+    
+    # execute the body of the script
+    LOGGER.info("Starting script")
+
+    main()
+
+    LOGGER.info("Finished script successfully.")


### PR DESCRIPTION
Fixes #459, #461, #462, #463
Currently our SWFs are not compatible with the OEB VRE infrastructure and must thus be run somewhere else. However, the output json files are supposed to comply with the OEB schemas, so that APAeval results can be uploaded into the OEB database and be visualized on the OEB website.   
In this PR the following changes have been made:
- specify correct time zone in `JSON_templates`, remove timestamp from manifest object
- for all `participant` objects, that is for all `validated_participant.challenge.json`, only save a single `participant` object that contains all challenge ids from all `validated_participant.challenge.json` in the `consolidated_results.json`.
- include objects from Manifest, containing participant and challenge ids, in `consolidated_results.json`
- for identification: save rogue metrics jsons in same directory as validated and assessment jsons
- for identification: fix wrong github `JSON_templates` requirement link
- fix errors raised by linter
- fixed by OEB: error caused by `barplot` in aggregation objects


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated corresponding READMEs (if applicable)
- [x] My code follows the templates/style guidelines of the repository
- [x] In- and output formats comply with APAeval specifications
- [x] No parameters or file names are hardcoded
- [x] Results, logs or other output is not commited to the repository
- [x] I have tested my code

